### PR TITLE
Add StandardRB template to replace Omakase linting

### DIFF
--- a/_templates/standard-rb/standard-rb.md
+++ b/_templates/standard-rb/standard-rb.md
@@ -1,0 +1,38 @@
+---
+layout: template
+title: StandardRB (Replace Omakase)
+description: Replace Rails default linting with StandardRB for zero-config Ruby style enforcement
+---
+
+Replaces rubocop-rails-omakase with [StandardRB](https://github.com/standardrb/standard), a zero-configuration Ruby style guide enforcer.
+
+## What It Does
+
+- Removes the `rubocop-rails-omakase` gem
+- Adds the `standard` gem to your development/test group
+- Replaces `.rubocop.yml` with StandardRB configuration
+- Removes `.rubocop_todo.yml` for a fresh start
+
+## After Installation
+
+Auto-fix your codebase:
+
+    bundle exec rubocop -A
+
+## Configuration
+
+The generated `.rubocop.yml` is intentionally minimal:
+
+    require: standard
+
+    inherit_gem:
+      standard: config/base.yml
+
+You can extend this with additional RuboCop plugins (rubocop-rails, rubocop-rspec, etc.) as needed.
+
+## Why StandardRB?
+
+StandardRB offers:
+- **Zero configuration** - no bikeshedding over style rules
+- **Community-driven** - based on the popular StandardJS philosophy
+- **Consistent** - same rules across all your Ruby projects

--- a/_templates/standard-rb/template.rb
+++ b/_templates/standard-rb/template.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+# StandardRB Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/standard-rb/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/standard-rb/template
+
+say "railstemplates.org"
+say "Replacing Omakase linting with StandardRB...", :green
+
+# Remove omakase gem (handles inline comments and indentation)
+gsub_file "Gemfile", /^\s*gem\s+["']rubocop-rails-omakase["'][^\n]*\n/, ""
+
+# Add standard gem
+gem_group :development, :test do
+  gem "standard", require: false
+end
+
+after_bundle do
+  remove_file ".rubocop_todo.yml"
+
+  create_file ".rubocop.yml", <<~YAML, force: true
+    require: standard
+
+    inherit_gem:
+      standard: config/base.yml
+  YAML
+
+  say "StandardRB installed. Run: bundle exec rubocop -A", :green
+end


### PR DESCRIPTION
## Summary

Adds a new Rails application template that replaces `rubocop-rails-omakase` with StandardRB.

- Removes `rubocop-rails-omakase` gem from Gemfile
- Adds `standard` gem to development/test group  
- Creates minimal `.rubocop.yml` with StandardRB configuration
- Removes `.rubocop_todo.yml` for a fresh start

## Usage

```bash
# New app
rails new myapp -m https://railstemplates.org/standard-rb/template

# Existing app
rails app:template LOCATION=https://railstemplates.org/standard-rb/template
```

## Generated .rubocop.yml

```yaml
require: standard

inherit_gem:
  standard: config/base.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)