### PR TITLE
Add StandardRB template to replace Omakase linting

### DIFF
--- a/_templates/standard-rb/standard-rb.md
+++ b/_templates/standard-rb/standard-rb.md
@@ -1,0 +1,38 @@
+---
+layout: template
+title: StandardRB (Replace Omakase)
+description: Replace Rails default linting with StandardRB for zero-config Ruby style enforcement
+---
+
+Replaces rubocop-rails-omakase with [StandardRB](https://github.com/standardrb/standard), a zero-configuration Ruby style guide enforcer.
+
+## What It Does
+
+- Removes the `rubocop-rails-omakase` gem
+- Adds the `standard` gem to your development/test group
+- Replaces `.rubocop.yml` with StandardRB configuration
+- Removes `.rubocop_todo.yml` for a fresh start
+
+## After Installation
+
+Auto-fix your codebase:
+
+    bundle exec rubocop -A
+
+## Configuration
+
+The generated `.rubocop.yml` is intentionally minimal:
+
+    require: standard
+
+    inherit_gem:
+      standard: config/base.yml
+
+You can extend this with additional RuboCop plugins (rubocop-rails, rubocop-rspec, etc.) as needed.
+
+## Why StandardRB?
+
+StandardRB offers:
+- **Zero configuration** - no bikeshedding over style rules
+- **Community-driven** - based on the popular StandardJS philosophy
+- **Consistent** - same rules across all your Ruby projects

--- a/_templates/standard-rb/template.rb
+++ b/_templates/standard-rb/template.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# StandardRB Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/standard-rb/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/standard-rb/template
+
+say "railstemplates.org"
+say "Replacing Omakase linting with StandardRB...", :green
+
+# Remove omakase gem and its comment
+gsub_file "Gemfile", /^\s*#.*rubocop-rails-omakase.*\n/, ""
+gsub_file "Gemfile", /^\s*gem\s+["']rubocop-rails-omakase["'][^\n]*\n/, ""
+
+# Add standard gem
+gem_group :development, :test do
+  gem "standard", require: false
+end
+
+after_bundle do
+  remove_file ".rubocop_todo.yml"
+
+  create_file ".rubocop.yml", <<~YAML, force: true
+    require:
+      - standard
+
+    plugins:
+      - standard-custom
+      - standard-performance
+      - rubocop-performance
+
+    inherit_gem:
+      standard: config/base.yml
+      standard-custom: config/base.yml
+      standard-performance: config/base.yml
+
+    AllCops:
+      NewCops: enable
+  YAML
+
+  say "StandardRB installed. Run: bundle exec rubocop -A", :green
+end


### PR DESCRIPTION
## Summary

- Adds new StandardRB template that replaces Rails' default `rubocop-rails-omakase` with StandardRB
- Removes the omakase gem and its comment from Gemfile
- Creates `.rubocop.yml` with the recommended StandardRB configuration using plugins API
- Enables NewCops by default

## Test plan

- [x] Created fresh Rails 8.1 app
- [x] Applied template successfully
- [x] Verified `rubocop -A` auto-fixes all correctable offenses
- [x] Confirmed `rubocop` passes with no offenses after auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)