### PR TITLE
Fix template URLs to use correct slugs

### DIFF
--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -31,13 +31,13 @@ layout: default
         </h2>
         
         <div class="mockup-code bg-neutral text-neutral-content mb-4">
-          <pre data-prefix="$"><code class="text-sm">rails app:template LOCATION={{ site.url }}/{{ page.title | slugify }}/template</code></pre>
+          <pre data-prefix="$"><code class="text-sm">rails app:template LOCATION={{ site.url }}/{{ page.slug }}/template</code></pre>
         </div>
         
         <div class="card-actions justify-between items-center">
           <div class="text-sm text-base-content/60">Copy and run this command</div>
           <button class="btn btn-primary btn-sm" onclick="copyToClipboard(this)" 
-                  data-text="rails app:template LOCATION={{ site.url }}/{{ page.title | slugify }}/template">
+                  data-text="rails app:template LOCATION={{ site.url }}/{{ page.slug }}/template">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
             </svg>
@@ -57,13 +57,13 @@ layout: default
         </h2>
         
         <div class="mockup-code bg-neutral text-neutral-content mb-4">
-          <pre data-prefix="$"><code class="text-sm">rails new myapp -m {{ site.url }}/{{ page.title | slugify }}/template</code></pre>
+          <pre data-prefix="$"><code class="text-sm">rails new myapp -m {{ site.url }}/{{ page.slug }}/template</code></pre>
         </div>
         
         <div class="card-actions justify-between items-center">
           <div class="text-sm text-base-content/60">Copy and run this command</div>
           <button class="btn btn-primary btn-sm" onclick="copyToClipboard(this)" 
-                  data-text="rails new myapp -m {{ site.url }}/{{ page.title | slugify }}/template">
+                  data-text="rails new myapp -m {{ site.url }}/{{ page.slug }}/template">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
             </svg>


### PR DESCRIPTION
Replace `page.title | slugify` with `page.slug` in template layout to generate correct download URLs.

Fixes incorrect URLs for simplecov-rails (was: simplecov-with-minitest-parallelism), standard-rb (was: standardrb-replace-omakase), and coverage-comments (was: coverage-pr-comments). The `page.slug` comes from the filename and matches directory names, unlike the slugified title which can produce different results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)