### PR TITLE
Add Email Image Tag template

### DIFF
--- a/_templates/email-image-tag/email-image-tag.md
+++ b/_templates/email-image-tag/email-image-tag.md
@@ -1,0 +1,33 @@
+---
+layout: template
+title: Email Image Tag
+description: Add a helper for inline image attachments in Action Mailer views
+---
+
+Adds an `email_image_tag` helper that simplifies inline image attachments in mailer views.
+
+## What It Does
+
+- Creates `app/helpers/email_helper.rb` with an `email_image_tag` method
+- Reads images from `app/assets/images/` and attaches them inline
+- Returns an `image_tag` referencing the inline attachment URL
+
+## Usage
+
+Place images in `app/assets/images/`, then use the helper in your mailer views:
+
+    <%= email_image_tag("logo.png", alt: "Company Logo", width: 200) %>
+
+This replaces the manual approach of attaching images in your mailer and referencing them in views:
+
+    # Before (in mailer)
+    attachments.inline["logo.png"] = File.binread("app/assets/images/logo.png")
+
+    # Before (in view)
+    <%= image_tag attachments["logo.png"].url, alt: "Company Logo", width: 200 %>
+
+## How It Works
+
+Action Mailer supports [inline attachments](https://guides.rubyonrails.org/action_mailer_basics.html#making-inline-attachments) via `attachments.inline`. The helper reads the image file, attaches it inline, and returns an `image_tag` pointing to the attachment's content URL — all in one call.
+
+Any additional keyword arguments (`alt:`, `width:`, `class:`, etc.) are passed through to `image_tag`.

--- a/_templates/email-image-tag/template.rb
+++ b/_templates/email-image-tag/template.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+# Email Image Tag Rails Application Template
+# Inspired by https://github.com/bullet-train-co/bullet_train-core/blob/main/bullet_train/app/helpers/email_helper.rb
+# Usage: rails new myapp -m https://railstemplates.org/email-image-tag/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/email-image-tag/template
+
+say "railstemplates.org"
+say "Adding email_image_tag helper...", :green
+
+create_file "app/helpers/email_helper.rb", <<~RUBY, force: true
+  module EmailHelper
+    def email_image_tag(image, **)
+      attachments.inline[image] = File.binread(Rails.root.join("app/assets/images", image))
+      image_tag(attachments.inline[image].url, **)
+    end
+  end
+RUBY
+
+say "EmailHelper installed. Use email_image_tag in your mailer views.", :green

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -59,6 +59,18 @@ class TemplatesTest < Minitest::Test
     assert_rails_boots
   end
 
+  def test_email_image_tag
+    create_rails_app
+    apply_template("email-image-tag")
+
+    assert File.exist?("#{@app_dir}/app/helpers/email_helper.rb")
+    helper = File.read("#{@app_dir}/app/helpers/email_helper.rb")
+    assert_match(/email_image_tag/, helper)
+    assert_match(/attachments\.inline/, helper)
+
+    assert_rails_boots
+  end
+
   def test_coverage_comments
     create_rails_app
     # First apply simplecov (prerequisite)


### PR DESCRIPTION
## Summary

Adds email_image_tag helper to simplify inline image attachments in Action Mailer views. Reads images from app/assets/images/ and attaches them inline with a single method call, replacing manual attachment boilerplate.

## Testing

Integration test added that creates a Rails app, applies the template, verifies the helper file is created correctly, and confirms the app boots.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)