### PR TITLE
Redesign: dark-first theme with red accent

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en' }}" data-theme="light">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 
 <head>
   <meta charset="utf-8">
@@ -11,21 +11,23 @@
   {%- feed_meta -%}
 </head>
 
-<body class="bg-gradient-to-br from-base-200 to-base-300 min-h-screen">
+<body class="bg-base-200 min-h-screen flex flex-col">
   <header class="py-8 px-4">
-    <div>
+    <div class="max-w-5xl mx-auto">
       <a href="{{ '/' | relative_url }}" class="inline-block w-1/2 md:w-1/3">
-        {% include logo.svg class="w-full h-auto fill-primary-content" %}
+        {% include logo.svg class="w-full h-auto fill-base-content" %}
       </a>
     </div>
   </header>
 
-  <main class="flex-1">
-    {{ content }}
+  <main class="flex-1 px-4">
+    <div class="max-w-5xl mx-auto">
+      {{ content }}
+    </div>
   </main>
 
-  <footer class="footer footer-center p-8 bg-base-100 text-base-content border-t border-base-300">
-    <div class="text-center">
+  <footer class="footer footer-center p-8 text-base-content border-t border-base-300">
+    <div class="max-w-5xl mx-auto text-center">
       <p class="font-semibold text-lg">{{ site.title | escape }}</p>
       <p class="text-base-content/70">{{ site.description | escape }}</p>
       <p class="text-sm text-base-content/50 mt-2">

--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -116,8 +116,8 @@ layout: default
 <style>
   /* Block code styling */
   .template-content .highlight {
-    background-color: oklch(var(--n));
-    color: oklch(var(--nc));
+    background-color: var(--color-neutral);
+    color: var(--color-neutral-content);
     border-radius: 0.5rem;
     padding: 1rem;
     overflow-x: auto;
@@ -138,8 +138,8 @@ layout: default
 
   /* Inline code styling */
   .template-content code.highlighter-rouge {
-    color: oklch(var(--a));
-    background-color: oklch(var(--a) / 0.1);
+    color: var(--color-accent);
+    background-color: color-mix(in oklch, var(--color-accent) 10%, transparent);
     padding: 0.25rem 0.5rem;
     border-radius: 0.375rem;
     font-weight: 500;

--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="px-4 py-8">
+<div class="py-8">
   <!-- Breadcrumbs -->
   <div class="breadcrumbs text-sm mb-6">
     <ul>

--- a/assets/tailwind/application.css
+++ b/assets/tailwind/application.css
@@ -8,29 +8,29 @@
 @plugin "./daisyui.js";
 @plugin "@tailwindcss/typography";
 
-/* Abyss theme */
+/* Dark theme (default) */
 :root {
   color-scheme: dark;
-  --color-base-100: oklch(25% 0.092 26.042);
-  --color-base-200: oklch(39% 0.141 25.723);
-  --color-base-300: oklch(44% 0.177 26.899);
-  --color-base-content: oklch(97% 0.013 17.38);
-  --color-primary: oklch(50% 0.213 27.518);
-  --color-primary-content: oklch(98% 0.003 247.858);
-  --color-secondary: oklch(83.27% 0.0764 298.3);
-  --color-secondary-content: oklch(43.27% 0.0764 298.3);
-  --color-accent: oklch(43% 0 0);
-  --color-accent-content: oklch(98% 0 0);
-  --color-neutral: oklch(30% 0.08 209);
-  --color-neutral-content: oklch(90% 0.076 70.697);
-  --color-info: oklch(74% 0.16 232.661);
-  --color-info-content: oklch(29% 0.066 243.157);
-  --color-success: oklch(79% 0.209 151.711);
-  --color-success-content: oklch(26% 0.065 152.934);
-  --color-warning: oklch(84.8% 0.1962 84.62);
-  --color-warning-content: oklch(44.8% 0.1962 84.62);
-  --color-error: oklch(65% 0.1985 24.22);
-  --color-error-content: oklch(27% 0.1985 24.22);
+  --color-base-100: oklch(21% 0.02 255);
+  --color-base-200: oklch(17% 0.015 255);
+  --color-base-300: oklch(25% 0.025 255);
+  --color-base-content: oklch(90% 0.01 250);
+  --color-primary: oklch(55% 0.22 25);
+  --color-primary-content: oklch(98% 0 0);
+  --color-secondary: oklch(70% 0.08 250);
+  --color-secondary-content: oklch(20% 0.03 250);
+  --color-accent: oklch(75% 0.15 55);
+  --color-accent-content: oklch(20% 0.05 55);
+  --color-neutral: oklch(25% 0.015 250);
+  --color-neutral-content: oklch(85% 0.01 250);
+  --color-info: oklch(74% 0.16 232);
+  --color-info-content: oklch(29% 0.066 243);
+  --color-success: oklch(79% 0.209 151);
+  --color-success-content: oklch(26% 0.065 152);
+  --color-warning: oklch(85% 0.196 84);
+  --color-warning-content: oklch(45% 0.196 84);
+  --color-error: oklch(65% 0.2 24);
+  --color-error-content: oklch(27% 0.2 24);
   --radius-selector: 2rem;
   --radius-field: 0.25rem;
   --radius-box: 0.5rem;
@@ -41,7 +41,37 @@
   --noise: 0;
 }
 
-/* Optional for custom themes – Docs: https://daisyui.com/docs/themes/#how-to-add-a-new-custom-theme */
-@plugin "./daisyui-theme.js"{
-  /* custom theme here */
+/* Light theme (OS preference) */
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --color-base-100: oklch(98% 0.005 70);
+    --color-base-200: oklch(95% 0.008 70);
+    --color-base-300: oklch(90% 0.012 70);
+    --color-base-content: oklch(25% 0.02 50);
+    --color-primary: oklch(50% 0.22 25);
+    --color-primary-content: oklch(98% 0 0);
+    --color-secondary: oklch(55% 0.08 250);
+    --color-secondary-content: oklch(98% 0.01 250);
+    --color-accent: oklch(55% 0.15 55);
+    --color-accent-content: oklch(98% 0.01 55);
+    --color-neutral: oklch(30% 0.015 250);
+    --color-neutral-content: oklch(95% 0.005 250);
+    --color-info: oklch(60% 0.16 232);
+    --color-info-content: oklch(98% 0.01 232);
+    --color-success: oklch(55% 0.2 151);
+    --color-success-content: oklch(98% 0.01 151);
+    --color-warning: oklch(70% 0.17 84);
+    --color-warning-content: oklch(25% 0.1 84);
+    --color-error: oklch(55% 0.22 25);
+    --color-error-content: oklch(98% 0 0);
+    --radius-selector: 2rem;
+    --radius-field: 0.25rem;
+    --radius-box: 0.5rem;
+    --size-selector: 0.25rem;
+    --size-field: 0.25rem;
+    --border: 1px;
+    --depth: 1;
+    --noise: 0;
+  }
 }

--- a/assets/tailwind/rouge-daisyui.css
+++ b/assets/tailwind/rouge-daisyui.css
@@ -1,11 +1,11 @@
 /* Rouge syntax highlighting theme using DaisyUI color variables */
 .highlight {
-  background: oklch(var(--b2));
-  color: oklch(var(--bc));
+  background: var(--color-base-200);
+  color: var(--color-base-content);
   border-radius: 0.5rem;
   padding: 1rem;
   overflow-x: auto;
-  border: 1px solid oklch(var(--b3));
+  border: 1px solid var(--color-base-300);
 }
 
 /* Code blocks */
@@ -22,84 +22,84 @@
 }
 
 /* Language-specific styling */
-.highlight .c   { color: oklch(var(--bc) / 0.6); font-style: italic }               /* Comment */
-.highlight .k   { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword */
-.highlight .kc  { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword.Constant */
-.highlight .kd  { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword.Declaration */
-.highlight .kn  { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword.Namespace */
-.highlight .kp  { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword.Pseudo */
-.highlight .kr  { color: oklch(var(--p)); font-weight: 600 }                        /* Keyword.Reserved */
-.highlight .kt  { color: oklch(var(--s)); font-weight: 600 }                        /* Keyword.Type */
+.highlight .c   { color: color-mix(in oklch, var(--color-base-content) 60%, transparent); font-style: italic }
+.highlight .k   { color: var(--color-primary); font-weight: 600 }
+.highlight .kc  { color: var(--color-primary); font-weight: 600 }
+.highlight .kd  { color: var(--color-primary); font-weight: 600 }
+.highlight .kn  { color: var(--color-primary); font-weight: 600 }
+.highlight .kp  { color: var(--color-primary); font-weight: 600 }
+.highlight .kr  { color: var(--color-primary); font-weight: 600 }
+.highlight .kt  { color: var(--color-secondary); font-weight: 600 }
 
-.highlight .s   { color: oklch(var(--su)) }                                         /* String */
-.highlight .s1  { color: oklch(var(--su)) }                                         /* String.Single */
-.highlight .s2  { color: oklch(var(--su)) }                                         /* String.Double */
-.highlight .se  { color: oklch(var(--wa)) }                                         /* String.Escape */
-.highlight .sh  { color: oklch(var(--su)) }                                         /* String.Heredoc */
-.highlight .si  { color: oklch(var(--in)) }                                         /* String.Interpol */
-.highlight .sr  { color: oklch(var(--er)) }                                         /* String.Regex */
-.highlight .ss  { color: oklch(var(--a)) }                                          /* String.Symbol */
+.highlight .s   { color: var(--color-success) }
+.highlight .s1  { color: var(--color-success) }
+.highlight .s2  { color: var(--color-success) }
+.highlight .se  { color: var(--color-warning) }
+.highlight .sh  { color: var(--color-success) }
+.highlight .si  { color: var(--color-info) }
+.highlight .sr  { color: var(--color-error) }
+.highlight .ss  { color: var(--color-accent) }
 
-.highlight .n   { color: oklch(var(--bc)) }                                         /* Name */
-.highlight .na  { color: oklch(var(--a)) }                                          /* Name.Attribute */
-.highlight .nb  { color: oklch(var(--in)) }                                         /* Name.Builtin */
-.highlight .nc  { color: oklch(var(--s)); font-weight: 600 }                        /* Name.Class */
-.highlight .nd  { color: oklch(var(--p)) }                                          /* Name.Decorator */
-.highlight .ne  { color: oklch(var(--er)); font-weight: 600 }                       /* Name.Exception */
-.highlight .nf  { color: oklch(var(--a)); font-weight: 600 }                        /* Name.Function */
-.highlight .nl  { color: oklch(var(--p)) }                                          /* Name.Label */
-.highlight .nn  { color: oklch(var(--s)) }                                          /* Name.Namespace */
-.highlight .no  { color: oklch(var(--er)) }                                         /* Name.Constant */
-.highlight .nv  { color: oklch(var(--bc)) }                                         /* Name.Variable */
+.highlight .n   { color: var(--color-base-content) }
+.highlight .na  { color: var(--color-accent) }
+.highlight .nb  { color: var(--color-info) }
+.highlight .nc  { color: var(--color-secondary); font-weight: 600 }
+.highlight .nd  { color: var(--color-primary) }
+.highlight .ne  { color: var(--color-error); font-weight: 600 }
+.highlight .nf  { color: var(--color-accent); font-weight: 600 }
+.highlight .nl  { color: var(--color-primary) }
+.highlight .nn  { color: var(--color-secondary) }
+.highlight .no  { color: var(--color-error) }
+.highlight .nv  { color: var(--color-base-content) }
 
-.highlight .m   { color: oklch(var(--in)) }                                         /* Number */
-.highlight .mb  { color: oklch(var(--in)) }                                         /* Number.Bin */
-.highlight .mf  { color: oklch(var(--in)) }                                         /* Number.Float */
-.highlight .mh  { color: oklch(var(--in)) }                                         /* Number.Hex */
-.highlight .mi  { color: oklch(var(--in)) }                                         /* Number.Integer */
-.highlight .mo  { color: oklch(var(--in)) }                                         /* Number.Oct */
+.highlight .m   { color: var(--color-info) }
+.highlight .mb  { color: var(--color-info) }
+.highlight .mf  { color: var(--color-info) }
+.highlight .mh  { color: var(--color-info) }
+.highlight .mi  { color: var(--color-info) }
+.highlight .mo  { color: var(--color-info) }
 
-.highlight .o   { color: oklch(var(--p)) }                                          /* Operator */
-.highlight .ow  { color: oklch(var(--p)); font-weight: 600 }                        /* Operator.Word */
+.highlight .o   { color: var(--color-primary) }
+.highlight .ow  { color: var(--color-primary); font-weight: 600 }
 
-.highlight .p   { color: oklch(var(--bc)) }                                         /* Punctuation */
+.highlight .p   { color: var(--color-base-content) }
 
-.highlight .cm  { color: oklch(var(--bc) / 0.6); font-style: italic }               /* Comment.Multiline */
-.highlight .cp  { color: oklch(var(--wa)); font-weight: 600 }                       /* Comment.Preproc */
-.highlight .c1  { color: oklch(var(--bc) / 0.6); font-style: italic }               /* Comment.Single */
-.highlight .cs  { color: oklch(var(--bc) / 0.6); font-style: italic; font-weight: 600 } /* Comment.Special */
+.highlight .cm  { color: color-mix(in oklch, var(--color-base-content) 60%, transparent); font-style: italic }
+.highlight .cp  { color: var(--color-warning); font-weight: 600 }
+.highlight .c1  { color: color-mix(in oklch, var(--color-base-content) 60%, transparent); font-style: italic }
+.highlight .cs  { color: color-mix(in oklch, var(--color-base-content) 60%, transparent); font-style: italic; font-weight: 600 }
 
-.highlight .gd  { color: oklch(var(--er)) }                                         /* Generic.Deleted */
-.highlight .gi  { color: oklch(var(--su)) }                                         /* Generic.Inserted */
-.highlight .gs  { font-weight: 600 }                                                /* Generic.Strong */
-.highlight .gu  { color: oklch(var(--bc) / 0.8); font-weight: 600 }                 /* Generic.Subheading */
+.highlight .gd  { color: var(--color-error) }
+.highlight .gi  { color: var(--color-success) }
+.highlight .gs  { font-weight: 600 }
+.highlight .gu  { color: color-mix(in oklch, var(--color-base-content) 80%, transparent); font-weight: 600 }
 
 /* Line numbers */
 .highlight .lineno {
-  color: oklch(var(--bc) / 0.4);
+  color: color-mix(in oklch, var(--color-base-content) 40%, transparent);
   user-select: none;
   margin-right: 1em;
   padding-right: 1em;
-  border-right: 1px solid oklch(var(--bc) / 0.2);
+  border-right: 1px solid color-mix(in oklch, var(--color-base-content) 20%, transparent);
 }
 
 /* Highlighted lines */
 .highlight .hll {
-  background-color: oklch(var(--b3));
+  background-color: var(--color-base-300);
 }
 
 /* Error highlighting */
 .highlight .err {
-  color: oklch(var(--er));
-  background-color: oklch(var(--er) / 0.1);
+  color: var(--color-error);
+  background-color: color-mix(in oklch, var(--color-error) 10%, transparent);
   border-radius: 0.25rem;
   padding: 0 0.25rem;
 }
 
 /* Inline code */
 :not(.highlight) > code {
-  background: oklch(var(--a) / 0.1);
-  color: oklch(var(--a));
+  background: color-mix(in oklch, var(--color-accent) 10%, transparent);
+  color: var(--color-accent);
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   font-size: 0.875em;

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Rails Templates
 ---
 
-<section class="py-8 px-4">
+<section class="py-8">
   <div>
     <p class="text-lg text-base-content/80 mb-8">
       Rails application templates are Ruby scripts that run during the <code class="badge badge-outline">rails new</code> 
@@ -35,7 +35,7 @@ title: Rails Templates
   </div>
 </section>
 
-<section id="templates" class="py-8 px-4">  
+<section id="templates" class="py-8">
   <div class="grid gap-6 sm:gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
     {% for template in site.templates %}
       <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105">


### PR DESCRIPTION
## Summary

- Replace all-red Abyss theme with dark slate default + light mode via `prefers-color-scheme`
- Red retained as primary accent color (buttons, links, card titles)
- Add centered `max-w-5xl` container for readability
- Fix rouge syntax highlighting to use DaisyUI 5 long-form CSS variables

## Test plan

- [x] `jekyll build` succeeds
- [x] All 5 template tests pass (48 assertions)
- [ ] Visual check: dark mode (OS dark) — slate background, red accents, readable text
- [ ] Visual check: light mode (OS light) — cream/stone background, red accents
- [ ] Check template detail pages for code block styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)