### PR TITLE
Fix SimpleCov template duplicate test group and indentation

### DIFF
--- a/_templates/simplecov-rails/template.rb
+++ b/_templates/simplecov-rails/template.rb
@@ -7,9 +7,15 @@
 say "railstemplates.org"
 say "📊 Installing SimpleCov with Minitest parallelism support...", :green
 
-# Add SimpleCov to Gemfile
-gem_group :test do
-  gem "simplecov", require: false
+# Add SimpleCov to Gemfile (inject into existing test group if present)
+if File.read("Gemfile").match?(/^group :test do/)
+  inject_into_file "Gemfile", after: "group :test do\n" do
+    "  gem \"simplecov\", require: false\n"
+  end
+else
+  gem_group :test do
+    gem "simplecov", require: false
+  end
 end
 
 after_bundle do
@@ -42,18 +48,18 @@ after_bundle do
   if File.read("test/test_helper.rb").include?("parallelize(workers: :number_of_processors)")
     say "⚙️  Adding Minitest parallelization support...", :blue
     inject_into_file "test/test_helper.rb", after: "parallelize(workers: :number_of_processors)\n" do
-      <<~'RUBY'
+<<'RUBY'
 
-      if ENV["CI"] || ENV["COVERAGE"]
-        parallelize_setup do |worker|
-          SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
-        end
-
-        parallelize_teardown do |worker|
-          SimpleCov.result
-        end
+    if ENV["CI"] || ENV["COVERAGE"]
+      parallelize_setup do |worker|
+        SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
       end
-    RUBY
+
+      parallelize_teardown do |worker|
+        SimpleCov.result
+      end
+    end
+RUBY
     end
     say "✓ Minitest parallelization support added", :green
   end

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -33,11 +33,18 @@ class TemplatesTest < Minitest::Test
 
     gemfile = File.read("#{@app_dir}/Gemfile")
     assert_match(/gem "simplecov"/, gemfile)
+    assert_equal 1, gemfile.scan(/group :test do/).count, "Expected exactly one group :test block in Gemfile"
 
     test_helper = File.read("#{@app_dir}/test/test_helper.rb")
     assert_match(/require "simplecov"/, test_helper)
     assert_match(/SimpleCov\.start/, test_helper)
     assert_match(/enable_coverage :branch/, test_helper)
+
+    # Verify parallelization hooks are indented to match class TestCase
+    assert_match(/^    if ENV\["CI"\].*\n      parallelize_setup/m, test_helper,
+      "parallelize_setup should be indented inside class TestCase")
+    assert_match(/^      parallelize_teardown/, test_helper,
+      "parallelize_teardown should be indented inside class TestCase")
 
     gitignore = File.read("#{@app_dir}/.gitignore")
     assert_match(%r{/coverage/}, gitignore)


### PR DESCRIPTION
## Summary

- **Duplicate test group**: `gem_group :test` always created a new `group :test` block in the Gemfile, even when one already existed. Now injects into the existing block when present.
- **Indentation**: `parallelize_setup`/`parallelize_teardown` were inserted with no indentation instead of matching the 4-space `class TestCase` nesting. Switched from `<<~'RUBY'` to `<<'RUBY'` heredoc to preserve correct whitespace.
- **Tests**: Added assertions verifying exactly one `group :test` block in the Gemfile and correct indentation of parallelization hooks.

## Test plan
- [x] `test_simplecov_rails` passes (17 assertions)
- [x] `test_coverage_comments` passes (dependent template still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)