### PR TITLE
feat: add appsignal-broadcast template

### DIFF
--- a/_templates/appsignal-broadcast/appsignal-broadcast.md
+++ b/_templates/appsignal-broadcast/appsignal-broadcast.md
@@ -1,0 +1,59 @@
+---
+layout: template
+title: AppSignal broadcast logger
+description: Compose Rails.logger to ship to STDOUT and AppSignal Logs at once, with sane filters and APM hygiene
+---
+
+Installs the [`appsignal`](https://github.com/appsignal/appsignal-ruby) gem and wires `Rails.logger` to broadcast to both STDOUT and AppSignal Logs in production. Every line lands in `journalctl` on the host **and** in AppSignal Logs as parsed JSON. Includes the operational sharp edges this composition needs to work in practice.
+
+## What It Does
+
+- Adds `gem "appsignal"` to the default group of your `Gemfile`
+- Creates `config/appsignal.rb` with:
+  - An `APPSIGNAL_FILTER_KEYS` baseline list of sensitive parameter and session keys
+  - `Appsignal.configure` activating dev/staging/production, with `instrument_net_http` on
+  - `filter_parameters` and `filter_session_data` pointed at `APPSIGNAL_FILTER_KEYS`
+  - `ignore_actions << "Rails::HealthController#show"` so `/up` stays out of APM samples
+- Creates `config/initializers/appsignal_filter_schema_events.rb` — prepends `AppsignalSchemaEventFilter` onto `Appsignal::Integrations::ActiveSupportNotificationsIntegration` to drop the duplicate `SCHEMA` `sql.active_record` events that AppSignal otherwise reads as N+1
+- Appends a sentinel-guarded broadcast block to `config/environments/production.rb` that builds `Appsignal::Logger#broadcast_to(stdout_logger)` and wraps the result in `ActiveSupport::TaggedLogging`
+
+## Why `Appsignal::Logger#broadcast_to`, not `ActiveSupport::BroadcastLogger`
+
+`ActiveSupport::BroadcastLogger` looks like the obvious wrapper, but it conflicts with `TaggedLogging` once one leg is `Appsignal::Logger`. The supported composition is the other way round: AppSignal's logger broadcasts to STDOUT, and the whole thing is wrapped in TaggedLogging.
+
+Each leg keeps its own level. `config.log_level = :info` only filters the AppSignal leg — the STDOUT logger is set explicitly with `level: log_level` (defaulting to `info`) to keep SolidQueue and friends from flooding `journalctl` at `:debug`.
+
+`silence_healthcheck_path` has the same level-independence issue and is not used here. Healthcheck filtering happens via lograge's `ignore_actions` (see the [`lograge`](/lograge/) template) **and** AppSignal's own `ignore_actions` — both lists are needed.
+
+## Filter Keys Sync Warning
+
+AppSignal's parameter filter is **exact string match**. No regexes, no symbols, no fuzzy matching. That means `APPSIGNAL_FILTER_KEYS` in `config/appsignal.rb` has to be kept manually in sync with the matching list in `config/initializers/filter_parameter_logging.rb`. Every time you add an integration-specific key — `r2_secret_access_key`, `aws_secret_access_key`, `appsignal_push_api_key`, a platform-specific session cookie — add it to **both** lists.
+
+The baseline shipped here covers the usual suspects: passwords, tokens, cookies, session ids, OTP/2FA codes, `rails_master_key`, SSN, CVV, salts, certificates.
+
+## SCHEMA Event Filter
+
+During connection setup, Rails publishes `sql.active_record` events at two nested `ActiveSupport::Notifications` levels with `payload[:name] == "SCHEMA"`. AppSignal's N+1 detector compares digests and reads the duplicate as a real N+1, polluting samples. The initializer prepends a module that returns early from `finish_event` for these and lets every other event through.
+
+## Idempotency
+
+Re-running the template is safe:
+
+- `gem "appsignal"` is added only if `Gemfile` does not already include it
+- `config/appsignal.rb` uses `create_file ..., skip: true`
+- `config/initializers/appsignal_filter_schema_events.rb` uses `create_file ..., skip: true`
+- The broadcast block in `config/environments/production.rb` is wrapped in sentinel markers (`# === appsignal-broadcast template start ===` / `# === appsignal-broadcast template end ===`) and is only appended when the start marker is absent
+
+Edit the generated files directly — the template will not overwrite your changes.
+
+## Composition
+
+- Stacks with [`lograge`](/lograge/): lograge's single-line JSON requests flow through the composed logger, so they appear in both `journalctl` and AppSignal Logs.
+- Stacks with `filter_parameter_logging.rb` (the matching baseline filter template) — keep `APPSIGNAL_FILTER_KEYS` and the Rails filter list in sync by hand.
+- AppSignal silently no-ops without `APPSIGNAL_PUSH_API_KEY` set, so the STDOUT leg still works locally and in environments without an AppSignal key.
+
+## Not Installed by This Template
+
+- `appsignal demo` / push-API-key bootstrapping — AppSignal's own CLI handles that
+- Setting `Appsignal.config.push_api_key` in code — use the `APPSIGNAL_PUSH_API_KEY` env var
+- Sentry / Honeybadger / Datadog wiring — different add-on, different template

--- a/_templates/appsignal-broadcast/template.rb
+++ b/_templates/appsignal-broadcast/template.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+# AppSignal broadcast-logger Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/appsignal-broadcast/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/appsignal-broadcast/template
+
+say "railstemplates.org"
+say "📡 Configuring AppSignal broadcast logger...", :green
+
+unless File.read("Gemfile").include?('"appsignal"')
+  gem "appsignal"
+end
+
+after_bundle do
+  appsignal_rb = <<~'RUBY'
+    # AppSignal configuration.
+    #
+    # APPSIGNAL_FILTER_KEYS is the AppSignal-shaped mirror of
+    # config/initializers/filter_parameter_logging.rb. AppSignal's filter is
+    # exact-string-match — no regexes, no symbols. Keep these two lists in
+    # sync manually whenever new sensitive keys are added.
+    APPSIGNAL_FILTER_KEYS = %w[
+      password password_confirmation
+      secret api_key access_token refresh_token bearer_token
+      authorization cookie set_cookie x_csrf_token csrftoken
+      sessionid session_id client_id client_secret webhook_secret
+      signed_id otp totp two_factor_code
+      rails_master_key ssn cvv cvc certificate salt
+    ].freeze
+
+    Appsignal.configure do |config|
+      config.activate_if_environment("development", "production", "staging")
+      config.name = Rails.application.class.module_parent_name
+
+      config.instrument_net_http = true
+
+      config.filter_parameters    = APPSIGNAL_FILTER_KEYS
+      config.filter_session_data  = APPSIGNAL_FILTER_KEYS
+
+      # Mirror lograge's ignore list to keep healthchecks out of APM samples.
+      config.ignore_actions << "Rails::HealthController#show"
+    end
+  RUBY
+
+  create_file "config/appsignal.rb", appsignal_rb, skip: true
+
+  schema_filter_rb = <<~'RUBY'
+    # Rails publishes SCHEMA `sql.active_record` events at two nested
+    # instrumentation levels during connection setup; AppSignal reads the
+    # duplicate digest as N+1.
+
+    return unless defined?(Appsignal::Integrations::ActiveSupportNotificationsIntegration)
+
+    module AppsignalSchemaEventFilter
+      def finish_event(name, payload = {})
+        return if name == "sql.active_record" && payload[:name] == "SCHEMA"
+        super
+      end
+    end
+
+    Appsignal::Integrations::ActiveSupportNotificationsIntegration
+      .singleton_class.prepend(AppsignalSchemaEventFilter)
+  RUBY
+
+  create_file "config/initializers/appsignal_filter_schema_events.rb", schema_filter_rb, skip: true
+
+  production_path = "config/environments/production.rb"
+
+  if File.exist?(production_path) && !File.read(production_path).include?("appsignal-broadcast template start")
+    broadcast_block = <<~'RUBY'
+
+      # === appsignal-broadcast template start ===
+      # Broadcast Rails.logger to STDOUT *and* AppSignal Logs.
+      #
+      # `Appsignal::Logger#broadcast_to` (NOT ActiveSupport::BroadcastLogger,
+      # which conflicts with TaggedLogging when one leg is Appsignal::Logger).
+      # Each leg keeps its own level. Set STDOUT level explicitly to avoid
+      # default :debug flooding journalctl.
+      log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+      raw_formatter = ->(_severity, _time, _progname, msg) { "#{msg}\n" }
+      stdout_logger = Logger.new($stdout, level: log_level).tap { |l| l.formatter = raw_formatter }
+      appsignal_logger = Appsignal::Logger.new("rails")
+      appsignal_logger.broadcast_to(stdout_logger)
+      config.logger = ActiveSupport::TaggedLogging.new(appsignal_logger)
+      config.log_level = log_level
+      # === appsignal-broadcast template end ===
+    RUBY
+
+    # Insert before the final `end` (the closer for Rails.application.configure).
+    inject_into_file production_path, broadcast_block, before: /^end\s*\z/
+  end
+
+  say ""
+  say "✅ AppSignal broadcast logger configured!", :green
+  say ""
+  say "📋 Next steps:", :blue
+  say "   • Set APPSIGNAL_PUSH_API_KEY in production (and staging/dev if you want them reporting)"
+  say "   • Keep APPSIGNAL_FILTER_KEYS in sync with config/initializers/filter_parameter_logging.rb"
+  say "   • Without APPSIGNAL_PUSH_API_KEY set, AppSignal silently no-ops — STDOUT still works"
+  say ""
+end

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -172,6 +172,66 @@ class TemplatesTest < Minitest::Test
     assert_rails_boots
   end
 
+  def test_appsignal_broadcast
+    create_rails_app
+    apply_template("appsignal-broadcast")
+
+    gemfile = File.read("#{@app_dir}/Gemfile")
+    assert_match(/gem "appsignal"/, gemfile)
+    assert_equal 1, gemfile.scan(/gem "appsignal"/).count,
+      "Expected exactly one appsignal gem entry in Gemfile"
+
+    appsignal_rb_path = "#{@app_dir}/config/appsignal.rb"
+    assert File.exist?(appsignal_rb_path), "config/appsignal.rb missing"
+    appsignal_rb = File.read(appsignal_rb_path)
+    assert_match(/APPSIGNAL_FILTER_KEYS\s*=/, appsignal_rb)
+    assert_match(/Appsignal\.configure do \|config\|/, appsignal_rb)
+    assert_match(/activate_if_environment/, appsignal_rb)
+    assert_match(/filter_parameters\s*=\s*APPSIGNAL_FILTER_KEYS/, appsignal_rb)
+    assert_match(/filter_session_data\s*=\s*APPSIGNAL_FILTER_KEYS/, appsignal_rb)
+    assert_match(/Rails::HealthController#show/, appsignal_rb)
+
+    schema_filter_path = "#{@app_dir}/config/initializers/appsignal_filter_schema_events.rb"
+    assert File.exist?(schema_filter_path), "appsignal_filter_schema_events.rb missing"
+    schema_filter = File.read(schema_filter_path)
+    assert_match(/module AppsignalSchemaEventFilter/, schema_filter)
+    assert_match(/sql\.active_record/, schema_filter)
+    assert_match(/SCHEMA/, schema_filter)
+    assert_match(/singleton_class\.prepend\(AppsignalSchemaEventFilter\)/, schema_filter)
+
+    production_path = "#{@app_dir}/config/environments/production.rb"
+    production_rb = File.read(production_path)
+    assert_match(/# === appsignal-broadcast template start ===/, production_rb)
+    assert_match(/# === appsignal-broadcast template end ===/, production_rb)
+    assert_match(/Appsignal::Logger\.new\("rails"\)/, production_rb)
+    assert_match(/broadcast_to\(stdout_logger\)/, production_rb)
+    assert_match(/ActiveSupport::TaggedLogging\.new\(appsignal_logger\)/, production_rb)
+    assert_equal 1, production_rb.scan(/appsignal-broadcast template start/).count,
+      "Sentinel start marker should appear exactly once"
+
+    # Idempotency: re-applying produces no further diff
+    appsignal_rb_before = File.read(appsignal_rb_path)
+    schema_filter_before = File.read(schema_filter_path)
+    production_rb_before = File.read(production_path)
+
+    apply_template("appsignal-broadcast")
+
+    gemfile_after = File.read("#{@app_dir}/Gemfile")
+    assert_equal 1, gemfile_after.scan(/gem "appsignal"/).count,
+      "Re-running the template must not add appsignal again"
+    assert_equal appsignal_rb_before, File.read(appsignal_rb_path),
+      "Re-running the template must not modify config/appsignal.rb"
+    assert_equal schema_filter_before, File.read(schema_filter_path),
+      "Re-running the template must not modify the schema-event filter initializer"
+    production_rb_after = File.read(production_path)
+    assert_equal production_rb_before, production_rb_after,
+      "Re-running the template must not modify config/environments/production.rb"
+    assert_equal 1, production_rb_after.scan(/appsignal-broadcast template start/).count,
+      "Re-running the template must not duplicate the sentinel block"
+
+    assert_rails_boots
+  end
+
   private
 
   def create_rails_app


### PR DESCRIPTION
## Summary

- Adds the `appsignal-broadcast` template: gem + `config/appsignal.rb` + SCHEMA-event filter initializer + a sentinel-guarded broadcast block appended to `config/environments/production.rb`.
- Uses `Appsignal::Logger#broadcast_to(stdout_logger)` wrapped in `ActiveSupport::TaggedLogging` (the only composition that survives — `ActiveSupport::BroadcastLogger` conflicts with TaggedLogging when one leg is `Appsignal::Logger`).
- Ships an `APPSIGNAL_FILTER_KEYS` baseline (passwords, tokens, cookies, OTPs, `rails_master_key`, etc.) and documents the manual-sync requirement against `filter_parameter_logging.rb` because AppSignal's filter is exact-string-match.

## Implementation notes

- Idempotency: `gem "appsignal"` is added only if absent from the Gemfile; both initializer files use `create_file ..., skip: true`; the production.rb append is guarded by the `# === appsignal-broadcast template start ===` sentinel.
- The broadcast block is inserted with `inject_into_file ..., before: /^end\s*\z/`, which lands it inside `Rails.application.configure do ... end` before the file's final `end`.
- `config.ignore_actions << "Rails::HealthController#show"` mirrors lograge's healthcheck filter — AppSignal needs its own copy because `silence_healthcheck_path` doesn't carry through the broadcast composition.

## Test plan

- [x] `bundle exec ruby -Itest test/templates_test.rb -n test_appsignal_broadcast` — 1 run, 43 assertions, 0 failures
- [x] `bundle exec jekyll build` — passes; `_site/appsignal-broadcast/{index.html,template}` generated
- [x] Test covers: gem appears exactly once, both initializer files exist with expected content, sentinel markers present exactly once, idempotency on re-apply (no file diffs, no duplicate sentinel), `assert_rails_boots` (verifies AppSignal silently no-ops without `APPSIGNAL_PUSH_API_KEY`)

Closes #37

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>