### PR TITLE
feat: add prosopite template

### DIFF
--- a/_templates/prosopite/prosopite.md
+++ b/_templates/prosopite/prosopite.md
@@ -1,0 +1,40 @@
+---
+layout: template
+title: Prosopite N+1 Detection
+description: Catch N+1 queries automatically — warn in development, raise in test, no-op in production
+---
+
+Installs [Prosopite](https://github.com/charkost/prosopite) and a single `config/initializers/prosopite.rb` that turns N+1 detection into a build-time signal. N+1s become test failures in CI, log warnings in local development, and stay out of the way in production.
+
+## What It Does
+
+- Adds the `prosopite` gem to your `Gemfile` (development + test groups)
+- Adds the `pg_query` gem (also dev + test) when `config/database.yml` indicates Postgres — Prosopite needs it to deduplicate queries on PG; SQLite and MySQL skip this
+- Creates `config/initializers/prosopite.rb` with:
+  - **Development:** loads the Rack middleware (`Prosopite::Middleware::Rack`) so every request is scanned, and writes warnings to a dedicated log
+  - **Test:** raises `Prosopite::NPlusOneQueriesError` the moment an N+1 is seen — your test suite is the enforcement layer
+  - **Production:** no-op. Prosopite is never auto-scanning live traffic.
+
+## Why These Defaults
+
+- **Raise in test, warn in dev.** A noisy warning is easy to ignore; a red test is not. The whole point of the template is to make N+1s impossible to merge.
+- **Rack middleware in dev only.** Auto-scanning every request is great for catching incidental N+1s while you click around, but it has measurable overhead. Production traffic never pays it.
+- **`pg_query` gated on adapter.** Prosopite's Postgres backend requires `pg_query` to fingerprint queries. Bundling it on SQLite/MySQL apps wastes a native extension build and confuses the dependency graph.
+- **Adapter detected from `config/database.yml`.** No runtime database connection needed — the template inspects the file Rails ships with.
+
+## Catching N+1s in Tests
+
+The initializer sets `Prosopite.rails_logger = true` and `Prosopite.raise = true` under `Rails.env.test?`, but tests still need to opt in per case (or globally) by wrapping the work in `Prosopite.scan` / `Prosopite.finish`. The simplest way is a `setup` / `teardown` pair in your base test case:
+
+```ruby
+class ActiveSupport::TestCase
+  setup    { Prosopite.scan }
+  teardown { Prosopite.finish }
+end
+```
+
+Any N+1 inside a test now raises `Prosopite::NPlusOneQueriesError` with the offending queries and the backtrace.
+
+## Re-running Safely
+
+The template is idempotent. If `config/initializers/prosopite.rb` already exists, it skips every step. If the `prosopite` gem is already in your `Gemfile`, it skips the gem additions. Edit the initializer freely — the template will not overwrite your changes.

--- a/_templates/prosopite/template.rb
+++ b/_templates/prosopite/template.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+
+# Prosopite Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/prosopite/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/prosopite/template
+
+say "railstemplates.org"
+say "🔎 Installing Prosopite for N+1 detection...", :green
+
+if File.exist?("config/initializers/prosopite.rb")
+  say "Prosopite initializer already present, skipping.", :yellow
+  return
+end
+
+# Detect Postgres adapter from config/database.yml. We inspect the file
+# (rather than connecting) so the template works before a DB exists.
+postgres_detected =
+  if File.exist?("config/database.yml")
+    database_yml = File.read("config/database.yml")
+    database_yml.include?("adapter: postgresql") || database_yml.include?("postgresql")
+  else
+    false
+  end
+
+# Add gems to a single :development, :test group block when one exists,
+# otherwise fall back to gem_group. This keeps the Gemfile tidy and
+# matches the convention used by other templates in this repo.
+def add_dev_test_gem(name, version: nil)
+  gemfile = File.read("Gemfile")
+  return if gemfile.include?(%(gem "#{name}"))
+
+  gem_line = version ? %(  gem "#{name}", "#{version}"\n) : %(  gem "#{name}"\n)
+
+  if gemfile.match?(/^group :development, :test do/)
+    inject_into_file "Gemfile", gem_line, after: "group :development, :test do\n"
+  else
+    gem_group :development, :test do
+      version ? gem(name, version) : gem(name)
+    end
+  end
+end
+
+add_dev_test_gem("prosopite")
+
+if postgres_detected
+  add_dev_test_gem("pg_query")
+else
+  say "Postgres not detected in config/database.yml — skipping pg_query.", :blue
+end
+
+after_bundle do
+  initializer_body = <<~'RUBY'
+    # Prosopite: catch N+1 queries automatically.
+    #   - development: log warnings + auto-scan every request via Rack middleware
+    #   - test:        raise Prosopite::NPlusOneQueriesError on first N+1
+    #   - production:  no-op
+    #
+    # Tests still need to wrap work in `Prosopite.scan` / `Prosopite.finish`.
+    # The simplest way is a setup/teardown pair in your base test case:
+    #
+    #   class ActiveSupport::TestCase
+    #     setup    { Prosopite.scan }
+    #     teardown { Prosopite.finish }
+    #   end
+
+    if Rails.env.development?
+      require "prosopite/middleware/rack"
+
+      Rails.application.config.after_initialize do
+        Prosopite.rails_logger = true
+        Prosopite.prosopite_logger = true
+      end
+
+      Rails.application.config.middleware.use(Prosopite::Middleware::Rack)
+    elsif Rails.env.test?
+      Rails.application.config.after_initialize do
+        Prosopite.rails_logger = true
+        Prosopite.raise = true
+      end
+    end
+  RUBY
+
+  create_file "config/initializers/prosopite.rb", initializer_body, skip: true
+
+  say "✅ Prosopite installed. N+1s will warn in development and raise in test.", :green
+  say "Wrap test work in Prosopite.scan / Prosopite.finish to enforce in CI.", :blue
+end

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -200,6 +200,44 @@ class TemplatesTest < Minitest::Test
     assert_rails_boots
   end
 
+  def test_prosopite
+    create_rails_app
+    apply_template("prosopite")
+
+    gemfile = File.read("#{@app_dir}/Gemfile")
+    assert_match(/gem "prosopite"/, gemfile)
+    assert_equal 1, gemfile.scan(/gem "prosopite"/).count,
+      "Expected exactly one prosopite gem entry in Gemfile"
+
+    # Default --minimal Rails app uses SQLite, so pg_query must NOT be added
+    refute_match(/gem "pg_query"/, gemfile,
+      "pg_query must not be added when Postgres is not detected")
+
+    initializer_path = "#{@app_dir}/config/initializers/prosopite.rb"
+    assert File.exist?(initializer_path)
+
+    initializer = File.read(initializer_path)
+    assert_match(/Rails\.env\.development\?/, initializer)
+    assert_match(/Rails\.env\.test\?/, initializer)
+    assert_match(/Prosopite\.raise = true/, initializer,
+      "test environment must raise on N+1")
+    assert_match(/Prosopite::Middleware/, initializer,
+      "development must register the Rack middleware")
+    assert_match(/Prosopite\.rails_logger = true/, initializer,
+      "development must log via Rails logger")
+
+    # Idempotency: re-applying the template produces no further diff
+    initializer_before = File.read(initializer_path)
+    apply_template("prosopite")
+    gemfile_after = File.read("#{@app_dir}/Gemfile")
+    assert_equal 1, gemfile_after.scan(/gem "prosopite"/).count,
+      "Re-running the template must not add prosopite again"
+    assert_equal initializer_before, File.read(initializer_path),
+      "Re-running the template must not modify the initializer"
+
+    assert_rails_boots
+  end
+
   private
 
   def create_rails_app


### PR DESCRIPTION
## Summary

- Adds `_templates/prosopite/` (template.rb + prosopite.md) that installs prosopite into the `:development, :test` group, gates `pg_query` on a Postgres adapter detected from `config/database.yml`, and writes `config/initializers/prosopite.rb` with env-gated behaviour (warn in development via `Prosopite::Middleware::Rack`, raise in test, no-op in production).
- Idempotent: re-applying the template skips the gem add when already present and short-circuits when the initializer file already exists.
- Adds `test_prosopite` to `test/templates_test.rb` asserting gem-count, pg_query absence on the default SQLite minimal app, initializer env gates, idempotency, and that Rails still boots.

## Test plan

- [x] `bundle exec ruby -Itest test/templates_test.rb -n test_prosopite` — 1 run, 20 assertions, 0 failures
- [x] `bundle exec jekyll build` — completes successfully (pre-existing `template.rb` shared-destination warning unchanged)
- [ ] Manual smoke: apply via `rails app:template LOCATION=…` against a Postgres app and confirm `pg_query` is added; against a SQLite app and confirm it is not

Closes #20

Generated with [Claude Code](https://claude.com/claude-code)