### PR TITLE
feat: add strong-migrations template

### DIFF
--- a/_templates/strong-migrations/strong-migrations.md
+++ b/_templates/strong-migrations/strong-migrations.md
@@ -1,0 +1,43 @@
+---
+layout: template
+title: Strong Migrations
+description: Catch unsafe migrations before they hit production — adds strong_migrations with start_after pinned to your current schema
+---
+
+Installs [strong_migrations](https://github.com/ankane/strong_migrations) and a `config/initializers/strong_migrations.rb` that pins `start_after` to the highest existing migration version. New migrations are checked for risky operations (adding `NOT NULL` columns to large tables, renaming columns, blocking locks, backfilling in the same migration, and more); your existing migrations stay untouched.
+
+## What It Does
+
+- Adds the `strong_migrations` gem to your `Gemfile` (default group, so it runs in development and CI)
+- Creates `config/initializers/strong_migrations.rb` with:
+  - `StrongMigrations.start_after = <current max migration version>` — every migration timestamp at or below this value is treated as "pre-existing" and never re-checked
+
+## Why `start_after`
+
+Strong Migrations runs its safety checks on every migration in your `db/migrate` directory. Without `start_after`, retrofitting it onto an existing app lights up your history with errors that you can't fix without rewriting committed migrations. Setting `start_after` to the largest current timestamp tells strong_migrations: "trust everything up to and including this point; police everything new from here on."
+
+The template computes the value by scanning `db/migrate/*.rb` and taking the largest numeric prefix. A fresh app with no migrations gets `start_after = 0`.
+
+## What You'll See
+
+Once installed, generating a risky migration fails fast with an actionable message:
+
+```
+=== Dangerous operation detected #strong_migrations ===
+
+Adding a NOT NULL column without a default is not safe. Use safer steps:
+  1. Add the column without NOT NULL
+  2. Backfill the column
+  3. Add the NOT NULL constraint
+```
+
+Each warning links to a remediation recipe in the [strong_migrations README](https://github.com/ankane/strong_migrations#checks).
+
+## Re-running Safely
+
+The template is idempotent:
+
+- The gem is added only if `strong_migrations` is not already in your `Gemfile`.
+- The initializer is created only if `config/initializers/strong_migrations.rb` does not already exist.
+
+Tweak `start_after` directly after install — the template will not overwrite your edits.

--- a/_templates/strong-migrations/template.rb
+++ b/_templates/strong-migrations/template.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# Strong Migrations Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/strong-migrations/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/strong-migrations/template
+
+say "railstemplates.org"
+say "🛡  Configuring Strong Migrations safety net...", :green
+
+unless File.read("Gemfile").include?('"strong_migrations"')
+  gem "strong_migrations"
+end
+
+after_bundle do
+  initializer_path = "config/initializers/strong_migrations.rb"
+
+  if File.exist?(initializer_path)
+    say "Strong Migrations initializer already present, skipping.", :yellow
+  else
+    migration_files = Dir.glob("db/migrate/*.rb")
+    start_after = migration_files
+      .map { |path| File.basename(path)[/\A(\d+)/, 1].to_i }
+      .max || 0
+
+    initializer_body = <<~RUBY
+      # Strong Migrations guards against risky schema changes (adding NOT NULL
+      # columns to large tables, renaming columns, blocking locks, backfilling
+      # inside the same migration, etc.) before they reach production.
+      #
+      # start_after pins the cutoff to the highest migration version that
+      # existed when this initializer was generated. Migrations at or below
+      # this timestamp are treated as pre-existing and skipped; new migrations
+      # are checked. Bump this value only when you intentionally want to
+      # silence checks on a freshly added migration.
+      StrongMigrations.start_after = #{start_after}
+    RUBY
+
+    create_file initializer_path, initializer_body
+    say "✅ Strong Migrations configured (start_after = #{start_after}).", :green
+  end
+end

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -172,6 +172,34 @@ class TemplatesTest < Minitest::Test
     assert_rails_boots
   end
 
+  def test_strong_migrations
+    create_rails_app
+    apply_template("strong-migrations")
+
+    gemfile = File.read("#{@app_dir}/Gemfile")
+    assert_match(/gem "strong_migrations"/, gemfile)
+    assert_equal 1, gemfile.scan(/gem "strong_migrations"/).count,
+      "Expected exactly one strong_migrations gem entry in Gemfile"
+
+    initializer_path = "#{@app_dir}/config/initializers/strong_migrations.rb"
+    assert File.exist?(initializer_path)
+
+    initializer = File.read(initializer_path)
+    assert_match(/StrongMigrations\.start_after = 0/, initializer,
+      "Fresh --minimal app has no migrations, so start_after should be 0")
+
+    # Idempotency: re-applying the template produces no further diff
+    gemfile_before = File.read("#{@app_dir}/Gemfile")
+    initializer_before = File.read(initializer_path)
+    apply_template("strong-migrations")
+    assert_equal gemfile_before, File.read("#{@app_dir}/Gemfile"),
+      "Re-running the template must not modify the Gemfile"
+    assert_equal initializer_before, File.read(initializer_path),
+      "Re-running the template must not modify the initializer"
+
+    assert_rails_boots
+  end
+
   private
 
   def create_rails_app


### PR DESCRIPTION
## Summary
- Adds the `strong-migrations` template that installs the [strong_migrations](https://github.com/ankane/strong_migrations) gem and a `config/initializers/strong_migrations.rb` initializer.
- `StrongMigrations.start_after` is pinned dynamically to the largest existing migration version in `db/migrate/*.rb` (defaults to `0` for fresh apps), so pre-existing migrations aren't retroactively flagged while new migrations are policed.
- Idempotent: the gem is added only when absent and the initializer is created only when missing — re-running produces no further diff.

## Test plan
- [x] `bundle exec ruby -Itest test/templates_test.rb --name test_strong_migrations` — passes (1 run, 10 assertions, 0 failures)
- [x] Full `bundle exec rake test` suite passes (9 runs, 124 assertions, 0 failures)
- [x] `bundle exec jekyll build` succeeds (pre-existing template.rb destination warnings only, applies to all templates uniformly)
- [x] Idempotency assertion: re-applying the template leaves the Gemfile and initializer byte-identical
- [x] `assert_rails_boots` confirms a Rails app with the template applied boots cleanly

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)