### PR TITLE
feat: add minitest-difftastic template

### DIFF
--- a/_templates/minitest-difftastic/minitest-difftastic.md
+++ b/_templates/minitest-difftastic/minitest-difftastic.md
@@ -1,0 +1,44 @@
+---
+layout: template
+title: minitest-difftastic
+description: Replace Minitest's line-based failure diffs with difftastic's syntax-aware, structural diffing
+---
+
+Installs [minitest-difftastic](https://github.com/marcoroth/minitest-difftastic) and wires it into `test/test_helper.rb`. When an assertion fails, the expected/actual diff is rendered by [difftastic](https://difftastic.wilfred.me.uk) — a structural, syntax-aware differ — instead of Minitest's default line-by-line output. Nested hashes, arrays, and objects line up by structure, so the part that actually changed is the part that's highlighted.
+
+## What It Does
+
+- Adds the `minitest-difftastic` gem to your `Gemfile` under `group :test`
+- Adds `Minitest.load(:difftastic) if Minitest.respond_to?(:load)` to `test/test_helper.rb`, just after `require "rails/test_help"`
+
+That's the whole install. The next failing assertion renders its diff through difftastic automatically.
+
+## Why the `respond_to?` Guard
+
+Minitest 6 stopped auto-loading plugins — you now have to ask for them by name with `Minitest.load(:difftastic)`. Minitest 5 had no such method and instead picked up any plugin present in the bundle automatically.
+
+The single guarded line covers both:
+
+- **Minitest 6:** `Minitest.load` is a public method, so the plugin is loaded explicitly.
+- **Minitest 5:** `Minitest.load` doesn't exist (only the private `Kernel#load`), so `respond_to?(:load)` is `false` and the line is skipped — the gem auto-loads from the bundle instead.
+
+No version detection, no branching in your test helper.
+
+## The difftastic Binary
+
+`minitest-difftastic` depends on [difftastic-ruby](https://github.com/marcoroth/difftastic-ruby), which ships **precompiled** native gems for the common platforms (`arm64-darwin`, `x86_64-darwin`, `arm64-linux`, `x86_64-linux`). You do **not** need to install difftastic separately — Bundler resolves the right binary for your platform.
+
+If CI runs on a different platform than your development machine, make sure that platform is in your lockfile so the precompiled gem is fetched there too:
+
+    bundle lock --add-platform x86_64-linux
+
+(`difftastic-ruby` requires Ruby 3.2+.)
+
+## Re-running Safely
+
+The template is idempotent:
+
+- The gem is added only if `minitest-difftastic` is not already in your `Gemfile`.
+- The load line is added only if `Minitest.load(:difftastic)` is not already in `test/test_helper.rb`.
+
+If your `test_helper.rb` has no `require "rails/test_help"` to anchor against, the load line is appended to the end instead.

--- a/_templates/minitest-difftastic/template.rb
+++ b/_templates/minitest-difftastic/template.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+# minitest-difftastic Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/minitest-difftastic/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/minitest-difftastic/template
+
+say "railstemplates.org"
+say "🌈 Installing minitest-difftastic for structural test diffs...", :green
+
+# Add minitest-difftastic to the test group. Inject into an existing
+# `group :test do` block when one is present (matching the convention used
+# by the other test-only templates here), otherwise create the block.
+gemfile = File.read("Gemfile")
+if gemfile.include?('gem "minitest-difftastic"')
+  say "minitest-difftastic already in Gemfile, skipping.", :yellow
+elsif gemfile.match?(/^group :test do/)
+  inject_into_file "Gemfile", %(  gem "minitest-difftastic"\n), after: "group :test do\n"
+else
+  gem_group :test do
+    gem "minitest-difftastic"
+  end
+end
+
+after_bundle do
+  test_helper = "test/test_helper.rb"
+
+  load_line = <<~'RUBY'
+    # minitest-difftastic renders failed-assertion diffs with difftastic's
+    # syntax-aware, structural diffing instead of Minitest's line-based output.
+    # Minitest 6 no longer auto-loads plugins, so load it explicitly. The guard
+    # is a no-op on Minitest 5, which still auto-loads plugins from the bundle.
+    Minitest.load(:difftastic) if Minitest.respond_to?(:load)
+  RUBY
+
+  if !File.exist?(test_helper)
+    say "No test/test_helper.rb found — add `Minitest.load(:difftastic)` yourself.", :yellow
+  elsif File.read(test_helper).include?("Minitest.load(:difftastic)")
+    say "minitest-difftastic already loaded in test_helper.rb, skipping.", :yellow
+  elsif File.read(test_helper).include?('require "rails/test_help"')
+    inject_into_file test_helper, "\n#{load_line}", after: %(require "rails/test_help"\n)
+    say "✅ minitest-difftastic loaded in test/test_helper.rb.", :green
+  else
+    append_to_file test_helper, "\n#{load_line}"
+    say "✅ minitest-difftastic load line appended to test/test_helper.rb.", :green
+  end
+end

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -238,6 +238,34 @@ class TemplatesTest < Minitest::Test
     assert_rails_boots
   end
 
+  def test_minitest_difftastic
+    create_rails_app
+    apply_template("minitest-difftastic")
+
+    gemfile = File.read("#{@app_dir}/Gemfile")
+    assert_match(/gem "minitest-difftastic"/, gemfile)
+    assert_equal 1, gemfile.scan(/gem "minitest-difftastic"/).count,
+      "Expected exactly one minitest-difftastic gem entry in Gemfile"
+
+    test_helper = File.read("#{@app_dir}/test/test_helper.rb")
+    assert_match(/Minitest\.load\(:difftastic\) if Minitest\.respond_to\?\(:load\)/, test_helper,
+      "test_helper must load the difftastic plugin guarded for Minitest 5/6")
+    # The load line must come after Minitest is required, or it raises NameError
+    assert_match(/require "rails\/test_help".*Minitest\.load\(:difftastic\)/m, test_helper,
+      "Minitest.load must appear after require \"rails/test_help\"")
+
+    # Idempotency: re-applying the template produces no further diff
+    gemfile_before = File.read("#{@app_dir}/Gemfile")
+    test_helper_before = File.read("#{@app_dir}/test/test_helper.rb")
+    apply_template("minitest-difftastic")
+    assert_equal gemfile_before, File.read("#{@app_dir}/Gemfile"),
+      "Re-running the template must not modify the Gemfile"
+    assert_equal test_helper_before, File.read("#{@app_dir}/test/test_helper.rb"),
+      "Re-running the template must not modify test_helper.rb"
+
+    assert_rails_boots
+  end
+
   private
 
   def create_rails_app


### PR DESCRIPTION
## Summary

Adds a `minitest-difftastic` template that swaps Minitest's line-based failure diffs for [difftastic](https://difftastic.wilfred.me.uk)'s syntax-aware, structural diffing. On a failing assertion, nested hashes/arrays/objects line up by structure so the changed part is the highlighted part.

## What it does

- Adds `gem "minitest-difftastic"` to the test group — injecting into an existing `group :test do` block when present, otherwise creating one (matching the other test-only templates here).
- After bundle, inserts `Minitest.load(:difftastic) if Minitest.respond_to?(:load)` into `test/test_helper.rb`, anchored just after `require "rails/test_help"` (appended to the end if that anchor is absent).

## Why the `respond_to?` guard

Minitest 6 stopped auto-loading plugins, so they must be requested explicitly via `Minitest.load`. Minitest 5 has no such method and auto-loads plugins from the bundle. The single guarded line covers both versions with no version detection: on 6 the plugin loads explicitly; on 5 the guard is false and the gem auto-loads.

## Idempotency

Both edits are guarded, so re-running the template is a no-op. The added test asserts exactly one gem entry, that the load line lands after `require "rails/test_help"`, that a second application produces no further diff to the Gemfile or test_helper, and that the resulting app still boots.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)