### PR TITLE
feat: add structured-logging template for JSON non-request logs

### DIFF
--- a/_templates/structured-logging/structured-logging.md
+++ b/_templates/structured-logging/structured-logging.md
@@ -1,0 +1,94 @@
+---
+layout: template
+title: Structured Logging
+description: One bare JSON object per log line to STDOUT/journalctl — jobs, external HTTP, Rails.event, and exceptions — optionally broadcast to AppSignal Logs
+---
+
+Creates a single `config/initializers/structured_logging.rb` that turns your **non-request** logs into one bare JSON object per line — Active Job executions, outgoing external HTTP requests, `Rails.event` app events, and unhandled exceptions. Each line goes to STDOUT (journalctl) and, when the `appsignal` gem is present, is broadcast to AppSignal Logs too. Active in `production` (and `staging`, if that environment exists); dev and test keep the default Rails logger.
+
+## Umbrella — Use Instead of the À La Carte Templates
+
+This template is an **umbrella**: it bundles the same subscribers that several single-purpose templates install on their own. Installing both doubles the output, because each initializer registers its own subscriber. Choose **either** this umbrella **or** the individual templates below — not both:
+
+- [active-job-json-logs](https://railstemplates.org/active-job-json-logs/template) — its `perform.active_job` subscriber is already included here.
+- [rails-event-json](https://railstemplates.org/rails-event-json/template) — its `Rails.event` subscriber is already included here.
+- [debug-exceptions-json](https://railstemplates.org/debug-exceptions-json/template) — its JSON exception prepend is already included here.
+
+If you also run [application-client](https://railstemplates.org/application-client/template), keep its `ApplicationClient` base class but delete the `config/initializers/application_client_logging.rb` it ships — this template already subscribes to `request.application_client`, so keeping both doubles the external-API lines.
+
+## Pairs With Lograge
+
+This template is **complementary** to the [Lograge template](https://railstemplates.org/lograge/template), which already emits one JSON line per HTTP request. It assumes lograge (or an equivalent) owns the per-request line and does **not** re-configure it. What this adds on top:
+
+- A **broadcast logger** that both lograge's request lines and the subscribers below flow through — STDOUT plus, optionally, AppSignal Logs.
+- **Structured subscribers** for the events lograge doesn't cover: background jobs, external API calls, `Rails.event`, and exceptions.
+
+Install both for full-coverage JSON logs. Lograge already ignores `/up` via `ignore_actions`, so health-check noise is handled there.
+
+## What It Does
+
+- Creates `config/initializers/structured_logging.rb` with:
+  - A **JSON-lines logger** composed in `production`/`staging`: a raw-formatted STDOUT logger, optionally wrapped in an `Appsignal::Logger` broadcast, then `ActiveSupport::TaggedLogging`.
+  - A `perform.active_job` subscriber — one JSON line per job execution with `queue`, `attempt`, `duration_ms`, `status`, and a filtered `args` list (records as GlobalIDs, hashes routed through `filter_parameters`), plus a cheap `ready_backlog` snapshot when SolidQueue is present.
+  - A `request.application_client` subscriber — one JSON line per outgoing external HTTP request (a no-op until the app has an `ApplicationClient`).
+  - A `Rails.event` subscriber — bridges every `Rails.event.notify(name, **fields)` into a JSON line, with a Rails 8.1 framework-namespace early-return to avoid duplicate lines.
+  - A `DebugExceptionsJson` prepend (production only) — one JSON line per unhandled exception instead of the default multi-line backtrace dump.
+
+## Payload Shape
+
+A background job logs as one line:
+
+```json
+{
+  "event": "job.perform",
+  "job": "DeliverEmailJob",
+  "queue": "default",
+  "attempt": 1,
+  "job_id": "a1b2c3d4-…",
+  "args": ["gid://app/User/42"],
+  "duration_ms": 128,
+  "status": "ok",
+  "ready_backlog": 3
+}
+```
+
+An unhandled exception logs as:
+
+```json
+{
+  "event": "request.exception",
+  "method": "GET",
+  "path": "/orders/999",
+  "request_id": "b1d2e5c6-…",
+  "exception": "ActiveRecord::RecordNotFound",
+  "message": "Couldn't find Order with 'id'=999",
+  "status": 404
+}
+```
+
+## The Silent Gotchas It Encodes
+
+Four non-obvious decisions the initializer bakes in — each of which silently breaks JSON logs if you get it wrong by hand:
+
+- **Raw STDOUT formatter.** `Logger`'s default formatter prepends `I, [2026-07-19T…#pid] INFO -- :` to every line, which turns each line into invalid JSON. The template installs a formatter that emits only `"#{msg}\n"`, so every line is a bare JSON object your aggregator can parse.
+- **`Appsignal::Logger#broadcast_to`, not `ActiveSupport::BroadcastLogger`.** `BroadcastLogger` conflicts with `TaggedLogging` when one leg is an `Appsignal::Logger`. `broadcast_to` fans the same lines out to both STDOUT and AppSignal Logs cleanly; AppSignal's default `AUTODETECT` format sniffs each line as JSON.
+- **Explicit STDOUT `level:`.** `Appsignal::Logger#add` writes to broadcast targets *before* applying its own level filter, so `config.log_level` only filters the AppSignal leg. Without an explicit level on the STDOUT logger, it defaults to `:debug` and SolidQueue's polling lines flood journalctl every poll cycle. The template sets it from `RAILS_LOG_LEVEL` (default `info`).
+- **Ignoring `/up`.** Health checks would otherwise dominate the request log — but that's handled by the **lograge** template's `ignore_actions`, not here. (In this broadcast setup, `config.silence_healthcheck_path` and `Rails.logger.silence` only silence the AppSignal leg, not STDOUT — `ignore_actions` short-circuits before the logger runs, which is why lograge owns it.)
+
+## Optional AppSignal Logs Broadcast
+
+The broadcast is **auto-detected**: if `Appsignal::Logger` is defined (i.e. the `appsignal` gem is loaded), lines are broadcast to AppSignal Logs in addition to STDOUT. If it isn't, the logger is a plain STDOUT logger and everything still works. There's nothing to configure — add the `appsignal` gem and the broadcast leg turns on. If `APPSIGNAL_PUSH_API_KEY` is unset, AppSignal silently no-ops and STDOUT still reaches journalctl.
+
+## Guarded Couplings
+
+The template applies cleanly to a **vanilla** Rails app — every integration is optional and guarded:
+
+- `SolidQueue::ReadyExecution.count` is guarded with `defined?` + `rescue` — apps without SolidQueue log without `ready_backlog`.
+- `Current.request_id` is guarded with `defined?`/`respond_to?` — apps without a `Current` class log without `request_id`.
+- The `request.application_client` subscriber is registered but is a no-op until the app has an `ApplicationClient` that instruments the event.
+- `Rails.event` is guarded, so pre-8.1 apps skip that subscriber.
+- `ActiveJob::LogSubscriber.detach_from` and the tagging/exception prepends only apply in `production`.
+
+## Re-running Safely
+
+The template is idempotent: if `config/initializers/structured_logging.rb` already exists, it skips every step. Tweak the initializer directly — the template will not overwrite your edits.

--- a/_templates/structured-logging/template.rb
+++ b/_templates/structured-logging/template.rb
@@ -1,0 +1,241 @@
+#!/usr/bin/env ruby
+
+# Structured Logging Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/structured-logging/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/structured-logging/template
+
+say "railstemplates.org"
+say "🪵 Configuring structured JSON logging...", :green
+
+if File.exist?("config/initializers/structured_logging.rb")
+  say "Structured logging initializer already present, skipping.", :yellow
+  return
+end
+
+after_bundle do
+  initializer_body = <<~'RUBY'
+    # Structured logging: one bare JSON object per line to STDOUT (journalctl)
+    # and, when the `appsignal` gem is present, to AppSignal Logs too.
+    #
+    # This pairs with the lograge template
+    # (https://railstemplates.org/lograge/template), which already emits one
+    # JSON line per HTTP request. This file is COMPLEMENTARY: it composes the
+    # broadcast logger those request lines flow through, plus subscribers that
+    # turn NON-request events (Active Jobs, outgoing HTTP, `Rails.event`,
+    # exceptions) into matching JSON lines. It does not re-configure lograge.
+    #
+    # Active in production (and staging, if that environment exists). Dev/test
+    # keep Rails' default human-readable logger.
+
+    if Rails.env.production? || Rails.env.staging?
+      # Compose a JSON-lines logger, reconfiguring Rails.logger.
+      #
+      #   1. STDOUT logger gets a RAW formatter (no `I, [ts #pid] INFO -- :`
+      #      prefix) so every line is a bare, valid JSON object straight to
+      #      journalctl.
+      #   2. If the `appsignal` gem is present, `Appsignal::Logger#broadcast_to`
+      #      fans the same lines out to AppSignal Logs. This is NOT
+      #      `ActiveSupport::BroadcastLogger`, which conflicts with
+      #      TaggedLogging when one leg is an `Appsignal::Logger`. AppSignal's
+      #      default `format: AUTODETECT` sniffs each line as JSON.
+      #   3. `ActiveSupport::TaggedLogging.new(...)` so callers can still use
+      #      `Rails.logger.tagged(...)`.
+      #
+      # `stdout.level` MUST be set explicitly. `Appsignal::Logger#add` writes to
+      # broadcast targets BEFORE applying its own level filter, so
+      # `config.log_level` only filters the AppSignal leg. Without an explicit
+      # STDOUT level, `Logger.new` defaults to :debug and SolidQueue's polling
+      # lines flood journalctl every poll cycle.
+      log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+      raw_formatter = ->(_severity, _time, _progname, msg) { "#{msg}\n" }
+      stdout_logger = Logger.new($stdout, level: log_level).tap { |l| l.formatter = raw_formatter }
+
+      logger =
+        if defined?(Appsignal::Logger)
+          appsignal_logger = Appsignal::Logger.new("rails")
+          appsignal_logger.broadcast_to(stdout_logger)
+          appsignal_logger
+        else
+          stdout_logger
+        end
+
+      Rails.logger = ActiveSupport::TaggedLogging.new(logger)
+    end
+
+    # Parameter filter shared by the subscribers below. Routes sensitive values
+    # (`:password`, `:token`, ...) through
+    # `Rails.application.config.filter_parameters` so they become `[FILTERED]`
+    # before they reach a log line.
+    def structured_logging_param_filter
+      @structured_logging_param_filter ||=
+        ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    end
+
+    # 1. `perform.active_job` — one JSON line per Active Job execution with
+    #    queue/attempt/duration/status and the serialized argument list.
+    #    Argument records are emitted as GlobalIDs; hash args are funnelled
+    #    through the parameter filter. `ready_backlog` is a cheap SolidQueue
+    #    snapshot, guarded so apps without SolidQueue log cleanly.
+    ActiveSupport::Notifications.subscribe("perform.active_job") do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      job = event.payload[:job]
+      err = event.payload[:exception_object]
+
+      serialized_args = Array(job.arguments).map do |arg|
+        if arg.respond_to?(:to_global_id)
+          arg.to_global_id.to_s
+        elsif arg.is_a?(Hash)
+          structured_logging_param_filter.filter(arg)
+        else
+          arg
+        end
+      end
+
+      request_id = defined?(Current) && Current.respond_to?(:request_id) ? Current.request_id : nil
+
+      ready_backlog =
+        begin
+          defined?(SolidQueue::ReadyExecution) ? SolidQueue::ReadyExecution.count : nil
+        rescue StandardError
+          nil
+        end
+
+      fields = {
+        event: "job.perform",
+        job: job.class.name,
+        queue: job.queue_name,
+        attempt: job.executions,
+        job_id: job.job_id,
+        request_id: request_id,
+        args: serialized_args.presence,
+        duration_ms: event.duration.to_i,
+        status: err ? "error" : "ok",
+        error_class: err&.class&.name,
+        ready_backlog: ready_backlog
+      }.compact
+
+      Rails.logger.info(fields.to_json)
+    end
+
+    # 2. `request.application_client` — one JSON line per outgoing external HTTP
+    #    request from an `ApplicationClient`-derived client. A no-op in apps
+    #    without an `ApplicationClient` (nothing instruments this event), but
+    #    kept so the subscriber is ready the moment one is added. URL query
+    #    strings, request bodies, and headers are intentionally NOT logged.
+    ActiveSupport::Notifications.subscribe("request.application_client") do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      err = event.payload[:exception_object]
+
+      request_id = defined?(Current) && Current.respond_to?(:request_id) ? Current.request_id : nil
+
+      fields = {
+        event: "external_api.request",
+        klass: event.payload[:klass],
+        method: event.payload[:method],
+        host: event.payload[:host],
+        path: event.payload[:path],
+        status: event.payload[:status],
+        duration_ms: event.duration.to_i,
+        attempt: event.payload[:attempt],
+        request_id: request_id,
+        error_class: err&.class&.name
+      }.compact
+
+      Rails.logger.info(fields.to_json)
+    end
+
+    # 3. `Rails.event` (Active Support's structured event reporter, Rails 8.1+)
+    #    — bridges every `Rails.event.notify(name, **fields)` call from app code
+    #    into a single flat JSON line. `Rails.event` auto-applies
+    #    `Rails.application.config.filter_parameters` before this subscriber
+    #    sees the payload.
+    #
+    #    `emit` early-returns for events in the Rails 8.1 framework
+    #    `StructuredEventSubscriber` namespaces (`action_controller.*`,
+    #    `active_job.*`, etc.). Those subscribers auto-attach at gem load and
+    #    republish framework `ActiveSupport::Notifications` events through
+    #    `Rails.event`; without the early-return, every HTTP request would emit
+    #    duplicate `action_controller.*` lines alongside lograge's per-request
+    #    line, every Active Storage op would emit `active_storage.*` lines, etc.
+    #    Filtering inside the subscriber (rather than `detach_from`-ing the
+    #    framework subscribers) leaves the `Rails.event` plumbing intact for any
+    #    other consumer.
+    if defined?(Rails.event) && Rails.event.respond_to?(:subscribe)
+      class StructuredLoggingEventSubscriber
+        RAILS_EVENT_NAMESPACES = %w[
+          action_controller action_dispatch action_view action_mailer
+          active_record active_storage active_job active_support
+        ].freeze
+
+        def emit(event)
+          return if framework_event?(event)
+
+          fields = {event: event[:name]}
+          fields.merge!(event[:payload]) if event[:payload].is_a?(Hash)
+          fields.merge!(event[:tags]) if event[:tags].is_a?(Hash) && event[:tags].any?
+          fields.merge!(event[:context]) if event[:context].is_a?(Hash) && event[:context].any?
+          fields[:source_location] = event[:source_location] if event[:source_location]
+          Rails.logger.info(fields.to_json)
+        end
+
+        private
+
+        def framework_event?(event)
+          event[:name].to_s.split(".").first.in?(RAILS_EVENT_NAMESPACES)
+        end
+      end
+
+      Rails.event.subscribe(StructuredLoggingEventSubscriber.new)
+    end
+
+    # 4. `DebugExceptionsJson` — one JSON line per unhandled exception (including
+    #    `ActionController::RoutingError` for unmatched paths). Replaces the
+    #    default multi-line `Class (message):` + annotated source + backtrace
+    #    output, which breaks JSON parsing in log aggregators. Backtraces are
+    #    still captured by error trackers (e.g. AppSignal Errors) via their own
+    #    instrumentation.
+    module StructuredLoggingDebugExceptionsJson
+      def log_error(request, wrapper)
+        Rails.logger.info({
+          event: "request.exception",
+          method: request.method,
+          path: request.filtered_path,
+          remote_ip: request.remote_ip,
+          request_id: request.request_id,
+          exception: wrapper.exception_class_name,
+          message: wrapper.message,
+          status: wrapper.status_code
+        }.compact.to_json)
+      end
+    end
+
+    # `ActiveJobNoTagging` — no-ops `ActiveJob::Base#tag_logger` so the
+    # `[ActiveJob] [JobClass] [job_id]` TaggedLogging prefix doesn't precede the
+    # `job.perform` JSON line above (the bracket prefix breaks JSON parsing).
+    # The same context is already in the line as `job`/`job_id` fields.
+    module StructuredLoggingActiveJobNoTagging
+      private def tag_logger(*_tags, &block) = block.call
+    end
+
+    # Only rewire the framework's own subscribers in production. In production
+    # we detach `ActiveJob::LogSubscriber` so jobs don't emit the classic
+    # multi-line `Performing`/`Performed` output alongside our JSON line, and
+    # prepend the two modules above.
+    if Rails.env.production?
+      Rails.application.config.after_initialize do
+        require "active_job/log_subscriber"
+        ActiveJob::LogSubscriber.detach_from(:active_job)
+        ActiveJob::Base.prepend(StructuredLoggingActiveJobNoTagging)
+        ActionDispatch::DebugExceptions.prepend(StructuredLoggingDebugExceptionsJson)
+      end
+    end
+  RUBY
+
+  create_file "config/initializers/structured_logging.rb", initializer_body, skip: true
+
+  environments = ["production"]
+  environments << "staging" if File.exist?("config/environments/staging.rb")
+  say "✅ Structured JSON logging configured for #{environments.join(" and ")}.", :green
+  say "Pairs with the lograge template for per-request JSON lines.", :blue
+  say "Dev/test continue using Rails' default logger.", :blue
+end

--- a/test/templates/structured_logging_test.rb
+++ b/test/templates/structured_logging_test.rb
@@ -1,0 +1,62 @@
+require_relative "../test_helper"
+
+class StructuredLoggingTest < TemplateTestCase
+  def test_structured_logging
+    create_rails_app
+    apply_template("structured-logging")
+
+    initializer_path = "#{@app_dir}/config/initializers/structured_logging.rb"
+    assert File.exist?(initializer_path)
+
+    initializer = File.read(initializer_path)
+    # Active only in production/staging; dev/test keep the default logger.
+    assert_match(/Rails\.env\.production\?/, initializer)
+    assert_match(/Rails\.env\.staging\?/, initializer)
+
+    # Silent gotchas the initializer must encode.
+    assert_match(/raw_formatter = ->\(_severity, _time, _progname, msg\)/, initializer,
+      "Must install a RAW formatter so each line is bare JSON with no severity prefix")
+    assert_match(/Logger\.new\(\$stdout, level: log_level\)/, initializer,
+      "STDOUT logger must set an explicit level so SolidQueue polling doesn't flood journalctl")
+    assert_match(/broadcast_to\(stdout_logger\)/, initializer,
+      "AppSignal leg must use Appsignal::Logger#broadcast_to")
+    refute_match(/ActiveSupport::BroadcastLogger\.new/, initializer,
+      "Must NOT use ActiveSupport::BroadcastLogger — it conflicts with TaggedLogging")
+    assert_match(/ActiveSupport::TaggedLogging\.new/, initializer)
+
+    # AppSignal broadcast is optional and auto-detected.
+    assert_match(/defined\?\(Appsignal::Logger\)/, initializer,
+      "AppSignal broadcast must be guarded so vanilla apps work")
+
+    # The four subscribers.
+    assert_match(/subscribe\("perform\.active_job"\)/, initializer)
+    assert_match(/subscribe\("request\.application_client"\)/, initializer)
+    assert_match(/Rails\.event\.subscribe/, initializer)
+    assert_match(/StructuredLoggingDebugExceptionsJson/, initializer)
+
+    # Framework-namespace early-return to avoid duplicate Rails.event lines.
+    assert_match(/RAILS_EVENT_NAMESPACES/, initializer)
+    assert_match(/framework_event\?/, initializer)
+
+    # Guarded couplings so a vanilla app applies cleanly.
+    assert_match(/defined\?\(SolidQueue::ReadyExecution\)/, initializer,
+      "SolidQueue must be guarded")
+    assert_match(/defined\?\(Current\).*Current\.respond_to\?\(:request_id\)/, initializer,
+      "Current.request_id must be guarded")
+
+    # Sensitive values routed through the app's parameter filter.
+    assert_match(/Rails\.application\.config\.filter_parameters/, initializer,
+      "Job args must be routed through filter_parameters")
+
+    # Only detach the framework ActiveJob subscriber in production.
+    assert_match(/ActiveJob::LogSubscriber\.detach_from/, initializer)
+
+    # Idempotency: re-applying the template produces no further diff.
+    initializer_before = File.read(initializer_path)
+    apply_template("structured-logging")
+    assert_equal initializer_before, File.read(initializer_path),
+      "Re-running the template must not modify the initializer"
+
+    assert_rails_boots
+  end
+end


### PR DESCRIPTION
## What it adds

A new `structured-logging` template that drops a single `config/initializers/structured_logging.rb`. It composes a **JSON-lines logger** — one bare JSON object per line to STDOUT (journalctl), optionally broadcast to AppSignal Logs — and registers subscribers that turn **non-request** events into matching JSON lines:

- `perform.active_job` — one line per Active Job execution (queue, attempt, duration, status, filtered args, SolidQueue backlog snapshot)
- `request.application_client` — one line per outgoing external HTTP request
- `Rails.event` — bridges every `Rails.event.notify(...)` app event into a JSON line
- `DebugExceptionsJson` (production) — one JSON line per unhandled exception instead of a multi-line backtrace dump

Active in `production` (and `staging` if that environment exists); dev/test keep the default Rails logger. Idempotent — skips if the initializer already exists.

## Usage

```
rails app:template LOCATION=https://railstemplates.org/structured-logging/template
```

## Complements the lograge template

This is **complementary** to the [lograge template](https://railstemplates.org/lograge/template), which already emits one JSON line per HTTP request. It does **not** duplicate lograge's per-request config — it composes the broadcast logger those request lines flow through and covers the events lograge doesn't. Health-check (`/up`) noise stays lograge's job via its `ignore_actions`.

## Optional AppSignal Logs broadcast

Auto-detected via `defined?(Appsignal::Logger)`: if the `appsignal` gem is present, lines broadcast to AppSignal Logs in addition to STDOUT using `Appsignal::Logger#broadcast_to`. No gem is added and nothing is configured — the broadcast leg turns on the moment the gem is loaded, and no-ops otherwise.

## Guarded couplings (works in a vanilla app)

Every integration is optional and guarded so the template applies cleanly to a plain `rails new --minimal` app with no AppSignal, SolidQueue, or `Current`:

- `SolidQueue::ReadyExecution.count` — `defined?` + `rescue`
- `Current.request_id` — `defined?`/`respond_to?`
- `request.application_client` subscriber — a no-op until the app has an `ApplicationClient`
- `Rails.event` — guarded, so pre-8.1 apps skip it
- `ActiveJob::LogSubscriber.detach_from` and the tagging/exception prepends — production only

## Silent gotchas it encodes

- **Raw STDOUT formatter** — drops the `I, [ts #pid] INFO -- :` prefix so each line is valid JSON.
- **`Appsignal::Logger#broadcast_to`, not `ActiveSupport::BroadcastLogger`** — the latter conflicts with `TaggedLogging` when a leg is an `Appsignal::Logger`.
- **Explicit STDOUT `level:`** — `Appsignal::Logger#add` writes to broadcast targets before its own level filter, so `config.log_level` only filters the AppSignal leg; without an explicit level, SolidQueue polling floods journalctl.
- **Ignoring `/up`** — handled by the lograge template's `ignore_actions`, not here.

Also includes a `Rails.event` framework-namespace early-return so framework `StructuredEventSubscriber`s (Rails 8.1) don't emit duplicate lines alongside lograge's per-request line.

## Tests

Adds `test_structured_logging` to `test/templates_test.rb`: applies the template to a minimal (vanilla) app, asserts the initializer's content shape and every guard, re-applies for idempotency, and confirms the app boots. Passes locally (1 run, 40 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)