### PR TITLE
feat: add json-logger template (extracted from #59)

### DIFF
--- a/_templates/json-logger/json-logger.md
+++ b/_templates/json-logger/json-logger.md
@@ -1,0 +1,51 @@
+---
+layout: template
+title: JSON Logger
+description: Compose Rails.logger so every line lands on STDOUT as a bare JSON object — optionally broadcast to AppSignal Logs
+---
+
+Creates a single `config/initializers/json_logger.rb` that composes `Rails.logger` into a **JSON-lines logger**: one bare JSON object per line to STDOUT (journalctl) and, when the `appsignal` gem is present, to AppSignal Logs as well. Active in `production` (and `staging`, if that environment exists); dev and test keep Rails' default human-readable logger.
+
+## This Is the Pipe, Not the Lines
+
+This template installs **no subscribers**. It only makes sure that whatever your app logs arrives as parseable JSON. Pair it with the templates that produce the lines:
+
+- [lograge](https://railstemplates.org/lograge/template) — one line per HTTP request
+- [active-job-json-logs](https://railstemplates.org/active-job-json-logs/template) — one line per Active Job execution
+- [application-client](https://railstemplates.org/application-client/template) — one line per outgoing external HTTP request
+- [rails-event-json](https://railstemplates.org/rails-event-json/template) — one line per `Rails.event.notify`
+- [debug-exceptions-json](https://railstemplates.org/debug-exceptions-json/template) — one line per unhandled exception
+
+Each is independent. Install the pipe plus whichever lines you want.
+
+## What It Does
+
+- Creates `config/initializers/json_logger.rb`, which in `production`/`staging`:
+  - Builds a STDOUT `Logger` with a **raw formatter** and an **explicit level** from `RAILS_LOG_LEVEL` (default `info`)
+  - Wraps it in an `Appsignal::Logger` broadcast **when the gem is loaded**, otherwise uses STDOUT alone
+  - Wraps the result in `ActiveSupport::TaggedLogging`
+  - Assigns it to both `Rails.logger` and `Rails.application.config.logger`
+
+## The Silent Gotchas It Encodes
+
+Three non-obvious decisions, each of which quietly breaks JSON logs if you get it wrong by hand:
+
+- **Raw STDOUT formatter.** `Logger`'s default formatter prepends `I, [2026-07-19T12:00:00#42] INFO -- : ` to every line, which turns a valid JSON object into something no aggregator can parse. The template installs a formatter that emits only `"#{msg}\n"`.
+- **`Appsignal::Logger#broadcast_to`, not `ActiveSupport::BroadcastLogger`.** `BroadcastLogger` conflicts with `TaggedLogging` when one leg is an `Appsignal::Logger`. `broadcast_to` fans the same lines out to both destinations cleanly, and AppSignal's default `AUTODETECT` format sniffs each line as JSON.
+- **Explicit STDOUT `level:`.** `Appsignal::Logger#add` writes to its broadcast targets *before* applying its own level filter, so `config.log_level` ends up filtering only the AppSignal leg. Without an explicit level, `Logger.new` defaults to `:debug` and debug chatter floods journalctl.
+
+## Why `config.logger` Too
+
+The initializer assigns the composed logger to `Rails.application.config.logger` as well as `Rails.logger`. Anything that reads `config.logger` later in the boot — including the lograge template's `config.lograge.logger = config.logger` — then picks up the composed logger instead of `nil`, so request lines flow through the same pipe as everything else rather than to lograge's own STDOUT logger.
+
+## Optional AppSignal Logs Broadcast
+
+The broadcast is **auto-detected** via `defined?(Appsignal::Logger)`. Add the `appsignal` gem and the AppSignal leg turns on; leave it out and the logger is a plain STDOUT logger. Nothing to configure either way. If `APPSIGNAL_PUSH_API_KEY` is unset, AppSignal silently no-ops and STDOUT still reaches journalctl.
+
+## Health Checks
+
+Health-check noise is **not** handled here. In a broadcast setup, `config.silence_healthcheck_path` and `Rails.logger.silence` only silence the AppSignal leg, not STDOUT — the level of each leg is independent. Filtering has to happen before the logger runs, which is why the [lograge](https://railstemplates.org/lograge/template) template owns it via `ignore_actions`.
+
+## Re-running Safely
+
+The template is idempotent: if `config/initializers/json_logger.rb` already exists, it skips every step. Tweak the initializer directly — the template will not overwrite your edits.

--- a/_templates/json-logger/template.rb
+++ b/_templates/json-logger/template.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+# JSON Logger Rails Application Template
+# Usage: rails new myapp -m https://railstemplates.org/json-logger/template
+# Usage: rails app:template LOCATION=https://railstemplates.org/json-logger/template
+
+say "railstemplates.org"
+say "🪵 Composing a JSON-lines logger (raw STDOUT + optional AppSignal broadcast)...", :green
+
+if File.exist?("config/initializers/json_logger.rb")
+  say "JSON logger initializer already present, skipping.", :yellow
+  return
+end
+
+initializer_body = <<~'RUBY'
+  # Composes `Rails.logger` so every line reaches STDOUT as a bare, valid JSON
+  # object — and, when the `appsignal` gem is present, AppSignal Logs too.
+  #
+  # This template installs the *pipe*, not the lines. The templates that emit
+  # JSON lines flow through it:
+  #
+  #   lograge                — one line per HTTP request
+  #   active-job-json-logs   — one line per Active Job execution
+  #   application-client     — one line per outgoing external HTTP request
+  #   rails-event-json       — one line per `Rails.event.notify`
+  #   debug-exceptions-json  — one line per unhandled exception
+  #
+  # Active in production (and staging, if that environment exists). Dev and test
+  # keep Rails' default human-readable logger.
+
+  return unless Rails.env.production? || Rails.env.staging?
+
+  # 1. The STDOUT logger gets a RAW formatter. `Logger`'s default prepends
+  #    `I, [2026-07-19T12:00:00#42] INFO -- : ` to every line, which turns an
+  #    otherwise-valid JSON object into something no aggregator can parse.
+  #
+  # 2. `level:` MUST be set explicitly here. `Appsignal::Logger#add` writes to
+  #    its broadcast targets BEFORE applying its own level filter, so
+  #    `config.log_level` ends up filtering only the AppSignal leg. Without an
+  #    explicit level, `Logger.new` defaults to `:debug` and debug-level chatter
+  #    floods journalctl.
+  log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  raw_formatter = ->(_severity, _time, _progname, msg) { "#{msg}\n" }
+  stdout_logger = Logger.new($stdout, level: log_level).tap { |l| l.formatter = raw_formatter }
+
+  # 3. If the `appsignal` gem is loaded, `Appsignal::Logger#broadcast_to` fans
+  #    the same lines out to AppSignal Logs. This is deliberately NOT
+  #    `ActiveSupport::BroadcastLogger`, which conflicts with `TaggedLogging`
+  #    when one leg is an `Appsignal::Logger`. AppSignal's default
+  #    `format: AUTODETECT` sniffs each line as JSON. With no
+  #    `APPSIGNAL_PUSH_API_KEY` set, AppSignal silently no-ops and STDOUT still
+  #    reaches journalctl.
+  logger =
+    if defined?(Appsignal::Logger)
+      Appsignal::Logger.new("rails").tap { |l| l.broadcast_to(stdout_logger) }
+    else
+      stdout_logger
+    end
+
+  # 4. `TaggedLogging` so callers can still use `Rails.logger.tagged(...)`.
+  composed_logger = ActiveSupport::TaggedLogging.new(logger)
+
+  Rails.logger = composed_logger
+  # Also assign `config.logger` so anything reading it during the rest of the
+  # boot picks up the composed logger rather than nil — the lograge template's
+  # `config.lograge.logger = config.logger` relies on this.
+  Rails.application.config.logger = composed_logger
+RUBY
+
+create_file "config/initializers/json_logger.rb", initializer_body, skip: true
+
+environments = ["production"]
+environments << "staging" if File.exist?("config/environments/staging.rb")
+say "✅ JSON logger composed for #{environments.join(" and ")}.", :green
+say "Dev/test continue using Rails' default logger.", :blue
+say "Set RAILS_LOG_LEVEL to change the STDOUT level (default: info).", :blue
+say "Add the appsignal gem to turn on the AppSignal Logs broadcast leg.", :blue

--- a/test/templates/json_logger_test.rb
+++ b/test/templates/json_logger_test.rb
@@ -1,0 +1,41 @@
+require_relative "../test_helper"
+
+class JsonLoggerTest < TemplateTestCase
+  def test_json_logger
+    create_rails_app
+    apply_template("json-logger")
+
+    initializer_path = "#{@app_dir}/config/initializers/json_logger.rb"
+    assert File.exist?(initializer_path)
+
+    initializer = File.read(initializer_path)
+
+    # Environment gate
+    assert_match(/return unless Rails\.env\.production\? \|\| Rails\.env\.staging\?/, initializer)
+
+    # Raw formatter, so each line is a bare JSON object
+    assert_match(/raw_formatter = ->\(_severity, _time, _progname, msg\) \{ "#\{msg\}\\n" \}/, initializer)
+    assert_match(/l\.formatter = raw_formatter/, initializer)
+
+    # Explicit STDOUT level from RAILS_LOG_LEVEL
+    assert_match(/ENV\.fetch\("RAILS_LOG_LEVEL", "info"\)/, initializer)
+    assert_match(/Logger\.new\(\$stdout, level: log_level\)/, initializer)
+
+    # Optional AppSignal broadcast leg, guarded on the gem being loaded
+    assert_match(/defined\?\(Appsignal::Logger\)/, initializer)
+    assert_match(/broadcast_to\(stdout_logger\)/, initializer)
+
+    # TaggedLogging wrapper, assigned to both Rails.logger and config.logger
+    assert_match(/ActiveSupport::TaggedLogging\.new\(logger\)/, initializer)
+    assert_match(/Rails\.logger = composed_logger/, initializer)
+    assert_match(/Rails\.application\.config\.logger = composed_logger/, initializer)
+
+    # Idempotency: re-applying the template produces no further diff
+    initializer_before = File.read(initializer_path)
+    apply_template("json-logger")
+    assert_equal initializer_before, File.read(initializer_path),
+      "Re-running the template must not modify the initializer"
+
+    assert_rails_boots
+  end
+end


### PR DESCRIPTION
## What it adds

A `json-logger` template that composes `Rails.logger` into a JSON-lines logger: one bare JSON object per line to STDOUT (journalctl) and, when the `appsignal` gem is loaded, broadcast to AppSignal Logs too. Active in `production` (and `staging`, if that environment exists); dev and test keep Rails' default logger.

It installs **the pipe, not the lines** — no subscribers. The templates that emit JSON lines flow through it: [lograge](https://railstemplates.org/lograge/template), [active-job-json-logs](https://railstemplates.org/active-job-json-logs/template), [application-client](https://railstemplates.org/application-client/template), [rails-event-json](https://railstemplates.org/rails-event-json/template), [debug-exceptions-json](https://railstemplates.org/debug-exceptions-json/template).

## Why not #59

#59 (`structured-logging`) bundled this composition with four subscribers that already ship as their own templates. Applying it alongside any of them registered a second subscriber for the same event, so every affected job / API call / `Rails.event.notify` logged twice — silently, with no error. Its own docs page had to carry an "umbrella — use instead of the à la carte templates" warning and an instruction to delete a file that `application-client` ships.

This is the companion template #43's closing note asked for: the broadcast logger as a distinct concern layered on top of the `appsignal` template, without rewriting `config/appsignal.rb` and without duplicating anyone's subscriber. Six one-job templates that compose, per CLAUDE.md.

## Gotchas it encodes

- **Raw STDOUT formatter** — `Logger`'s default prepends `I, [ts #pid] INFO -- : `, which makes each line invalid JSON.
- **`Appsignal::Logger#broadcast_to`, not `ActiveSupport::BroadcastLogger`** — the latter conflicts with `TaggedLogging` when one leg is an `Appsignal::Logger`.
- **Explicit STDOUT `level:`** — `Appsignal::Logger#add` writes to broadcast targets *before* applying its own level filter, so `config.log_level` only filters the AppSignal leg.

## Deliberately not included

- `config.solid_queue.silence_polling` (in usingrails' `production.rb`) — `mattr_accessor :silence_polling, default: true` in solid_queue 1.6.0, so pinning it is a figment.
- `config.log_level = ...` — dead in an initializer; the `initialize_logger` bootstrap has already read it. The explicit level goes on the STDOUT logger, where it applies.

## Also assigns `config.logger`

Not just `Rails.logger`, so the lograge template's `config.lograge.logger = config.logger` picks up the composed logger rather than `nil` and request lines flow through the same pipe.

## Tests

`test/templates/json_logger_test.rb` — applies to a vanilla `--minimal` app, asserts the env gate, raw formatter, explicit level, guarded AppSignal leg, `TaggedLogging` wrapper and both logger assignments, re-applies for idempotency, and confirms the app boots. 1 run, 24 assertions, 0 failures. `bundle exec jekyll build` generates `_site/json-logger/{index.html,template}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)