### PR TITLE
feat: verify the Litestream replica on a daily schedule

### DIFF
--- a/_templates/litestream/litestream.md
+++ b/_templates/litestream/litestream.md
@@ -15,6 +15,7 @@ The one non-default this template adds — and the entire reason it exists — i
   - `config/litestream.yml` — the Litestream config (databases + replicas)
   - `config/initializers/litestream.rb` — wires the gem's `config.litestream.*` settings to ENV / Rails credentials
 - Injects `sync-interval: 10s` into every replica in `config/litestream.yml`, with an inline comment explaining the trade-off
+- Schedules the gem's `Litestream::VerificationJob` daily in `config/recurring.yml`, if that file exists
 
 ## Why `sync-interval: 10s` — The Whole Point
 
@@ -71,6 +72,22 @@ This keeps replication independent of request traffic — a slow or hung web pro
 
 Either way, the replica **bucket and credentials** are read from `config/initializers/litestream.rb`, which pulls them from ENV variables (`LITESTREAM_REPLICA_BUCKET`, `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`) or Rails encrypted credentials. Edit that initializer to point at your storage provider.
 
+## Verifying the Replica
+
+A replica nobody reads back is a directory of files you hope are a database. The `litestream` gem ships a job for this — `Litestream::VerificationJob` calls `Litestream.verify!` on each configured database, which restores it from the replica and reads it back. The template schedules it daily:
+
+```yaml
+production:
+  litestream_backup_verification:
+    class: Litestream::VerificationJob
+    args: []
+    schedule: every day at 1am UTC
+```
+
+This matters *more* because of the `sync-interval` change above, not less. Stretching the interval to 10s widens the window in which a silently broken replica looks exactly like a healthy one — fewer writes means fewer chances for a failing upload to announce itself. A daily read-back is what closes that gap.
+
+The entry goes under an existing `production:` key if there is one, preserving any recurring jobs already there. Apps without `config/recurring.yml` (no Solid Queue) get a reminder to schedule it themselves instead.
+
 ## Re-running Safely
 
-The template is idempotent. If `config/litestream.yml` already exists it skips every step — it won't re-run the generator and won't inject a second `sync-interval`. Tweak the generated `config/litestream.yml` and `config/initializers/litestream.rb` directly; the template will not overwrite your edits.
+The template is idempotent. If `config/litestream.yml` already exists it skips every step — it won't re-run the generator, won't inject a second `sync-interval`, and won't schedule a second verification job. Tweak the generated `config/litestream.yml` and `config/initializers/litestream.rb` directly; the template will not overwrite your edits.

--- a/_templates/litestream/template.rb
+++ b/_templates/litestream/template.rb
@@ -59,6 +59,37 @@ after_bundle do
     say "config/litestream.yml not found — run `bin/rails generate litestream:install` first.", :yellow
   end
 
+  # Schedule the replica verification the gem already ships. `Litestream.verify!`
+  # restores each configured database from its replica and reads it back, which
+  # is the only thing that distinguishes a working backup from a directory of
+  # files you have never opened. It matters more here, not less: the 10s
+  # sync-interval above widens the window a silent replication failure can hide
+  # in.
+  # Indent explicitly rather than relying on the heredoc: `<<~` strips the
+  # smallest common indentation, which would flatten the entry to column 0 and
+  # make the next existing key a child of ours.
+  verification_entry = <<~YAML.lines.map { |line| "  #{line}" }.join
+    litestream_backup_verification:
+      class: Litestream::VerificationJob
+      args: []
+      schedule: every day at 1am UTC
+  YAML
+
+  recurring_yml = "config/recurring.yml"
+
+  if !File.exist?(recurring_yml)
+    say "No config/recurring.yml (no Solid Queue?) — skipping the verification schedule.", :yellow
+    say "Schedule Litestream::VerificationJob yourself so the replica gets read back.", :yellow
+  elsif File.read(recurring_yml).include?("Litestream::VerificationJob")
+    say "Litestream::VerificationJob already scheduled, leaving it alone.", :yellow
+  elsif File.read(recurring_yml).match?(/^production:\s*$/)
+    inject_into_file recurring_yml, "\n#{verification_entry}", after: /^production:\s*\n/
+    say "✅ Scheduled Litestream::VerificationJob daily in config/recurring.yml.", :green
+  else
+    append_to_file recurring_yml, "\nproduction:\n#{verification_entry}"
+    say "✅ Added a production: block scheduling Litestream::VerificationJob.", :green
+  end
+
   say ""
   say "✅ Litestream configured.", :green
   say ""

--- a/test/templates/litestream_test.rb
+++ b/test/templates/litestream_test.rb
@@ -1,8 +1,20 @@
 require_relative "../test_helper"
+require "yaml"
 
 class LitestreamTest < TemplateTestCase
   def test_litestream
     create_rails_app
+
+    # A --minimal app has no Solid Queue and so no config/recurring.yml. Write
+    # one with a production: key so the verification schedule has somewhere to go.
+    recurring_path = "#{@app_dir}/config/recurring.yml"
+    File.write(recurring_path, <<~YAML)
+      production:
+        existing_entry:
+          command: "Rails.logger.info('untouched')"
+          schedule: every hour
+    YAML
+
     apply_template("litestream")
 
     gemfile = File.read("#{@app_dir}/Gemfile")
@@ -26,10 +38,39 @@ class LitestreamTest < TemplateTestCase
     assert_match(/^ {8}sync-interval: 10s/, config,
       "sync-interval should be indented to sit inside the replica mapping")
 
+    # The gem's own verification job, scheduled daily under the existing
+    # production: key. An unread replica isn't a backup, and the 10s
+    # sync-interval widens the window a silent replication failure hides in.
+    recurring = File.read(recurring_path)
+    assert_match(/class: Litestream::VerificationJob/, recurring)
+    assert_match(/schedule: every day at 1am UTC/, recurring)
+    assert_match(/^  litestream_backup_verification:$/, recurring,
+      "entry should be indented as a child of production:")
+    assert_match(/existing_entry:/, recurring,
+      "existing recurring entries must be preserved")
+    assert_equal 1, recurring.scan(/^production:$/).count,
+      "must reuse the existing production: key rather than adding a second"
+
+    # Both entries must parse as siblings under production: — a mis-indented
+    # injection would still match the regexes above while nesting one inside
+    # the other.
+    parsed = YAML.safe_load(recurring)
+    assert_equal %w[litestream_backup_verification existing_entry].sort,
+      parsed["production"].keys.sort
+    assert_equal "Litestream::VerificationJob",
+      parsed.dig("production", "litestream_backup_verification", "class")
+    assert_equal "every day at 1am UTC",
+      parsed.dig("production", "litestream_backup_verification", "schedule")
+
     # Idempotency: re-applying the template produces no further diff
     gemfile_before = File.read("#{@app_dir}/Gemfile")
     config_before = File.read(config_path)
+    recurring_before = File.read(recurring_path)
     apply_template("litestream")
+    assert_equal recurring_before, File.read(recurring_path),
+      "Re-running the template must not modify config/recurring.yml"
+    assert_equal 1, File.read(recurring_path).scan(/Litestream::VerificationJob/).count,
+      "Re-running the template must not schedule a second verification job"
     assert_equal gemfile_before, File.read("#{@app_dir}/Gemfile"),
       "Re-running the template must not modify the Gemfile"
     assert_equal config_before, File.read(config_path),


### PR DESCRIPTION
## What it adds

Schedules the `litestream` gem's own `Litestream::VerificationJob` daily in `config/recurring.yml`:

```yaml
production:
  litestream_backup_verification:
    class: Litestream::VerificationJob
    args: []
    schedule: every day at 1am UTC
```

The job calls `Litestream.verify!` on each configured database, which restores it from the replica and reads it back. That read-back is the only thing separating a working backup from a directory of files nobody has ever opened.

Taken from `config/recurring.yml` in bridgingledger, which has run this daily in production.

## Why this belongs in *this* template

The `sync-interval: 10s` change #60 exists to make is exactly what makes verification matter more, not less. Fewer writes means fewer chances for a failing upload to announce itself, so a silently broken replica looks identical to a healthy one for longer. A daily read-back closes the window the interval opened.

## Behaviour

| App state | What happens |
|---|---|
| `config/recurring.yml` with a `production:` key | Entry injected under it; existing recurring jobs preserved |
| `config/recurring.yml` without `production:` | A `production:` block is appended |
| No `config/recurring.yml` (no Solid Queue) | Prints a reminder to schedule it yourself |
| Job already scheduled | Left alone |

## One implementation note

The entry is indented explicitly (`.lines.map { "  #{line}" }`) rather than via `<<~`. `<<~` strips the smallest common indentation, which flattens the entry to column 0 — and a column-0 entry makes the *next* existing key a child of ours instead of a sibling. That was the first version of this, and it's why the test now parses the YAML instead of only regex-matching it: the mis-indented output satisfied every regex while producing the wrong document.

```ruby
parsed = YAML.safe_load(recurring)
assert_equal %w[litestream_backup_verification existing_entry].sort,
  parsed["production"].keys.sort
```

## Tests

`test/templates/litestream_test.rb` seeds a `config/recurring.yml` with an existing `production:` entry (a `--minimal` app has no Solid Queue), then asserts the entry lands as a sibling, the existing one survives, there's exactly one `production:` key, the document parses, and a re-apply changes nothing. 1 run, 29 assertions, 0 failures. `bundle exec jekyll build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)