### PR TITLE
refactor: move the request-id setter into a controller concern

### DIFF
--- a/_templates/request-id-context/request-id-context.md
+++ b/_templates/request-id-context/request-id-context.md
@@ -4,13 +4,14 @@ title: Request-ID Context
 description: Per-request id propagation through Current, ApplicationJob, and ActiveSupport — plus a sensible filter_parameters baseline
 ---
 
-Installs the small substrate every structured-log template depends on: a `Current.request_id` slot, request-id propagation through `ApplicationJob` (enqueue → serialize → deserialize → perform), an `ApplicationController` `before_action` to populate both `Current` and `Rails.event` context, and a sensible `config/initializers/filter_parameter_logging.rb` baseline.
+Installs the small substrate every structured-log template depends on: a `Current.request_id` slot, request-id propagation through `ApplicationJob` (enqueue → serialize → deserialize → perform), a `SetCurrentRequestId` controller concern that populates both `Current` and `Rails.event` context, and a sensible `config/initializers/filter_parameter_logging.rb` baseline.
 
 ## What It Does
 
 - **`app/models/current.rb`** — adds `attribute :request_id` to your `Current` class (creates the class if absent)
 - **`app/jobs/application_job.rb`** — adds an `attr_accessor :request_id`, a `before_enqueue` hook capturing the current request id, `serialize`/`deserialize` overrides so the id rides through the job store, and a `perform_now` wrapper that re-establishes `Current.request_id` and `Rails.event` context for the duration of `perform`
-- **`app/controllers/application_controller.rb`** — adds a `before_action` that copies `request.request_id` into `Current.request_id` and (when present) `Rails.event.set_context`
+- **`app/controllers/concerns/set_current_request_id.rb`** — a concern whose `before_action` copies `request.request_id` into `Current.request_id` and (when present) `Rails.event.set_context`
+- **`app/controllers/application_controller.rb`** — gains one line: `include SetCurrentRequestId`
 - **`config/initializers/filter_parameter_logging.rb`** — replaces Rails' stock single-line file with a three-layer baseline: short keyword fragments, common explicit names (webhook_secret, rails_master_key, totp, …), and a default-deny regex for any key ending in `token`, `secret`, `key`, `password`, `cookie`, or `authorization`
 
 ## Why These Defaults
@@ -18,6 +19,7 @@ Installs the small substrate every structured-log template depends on: a `Curren
 - **`Current.request_id`, not a thread-local.** `ActiveSupport::CurrentAttributes` is reset between requests and propagates through `Current.set { ... }` blocks — exactly what you want when a job re-establishes the originating request id mid-perform.
 - **`before_enqueue` + `serialize`/`deserialize`.** Capturing the id at enqueue time (rather than at perform time) means the id survives a retry: SolidQueue re-deserializes the same payload, and the job's log lines stay joined to the request that triggered it.
 - **`perform_now` wrapper, not `around_perform`.** Wrapping `perform_now` rather than using an `around_perform` callback means `Rails.event.set_context` runs even if a subclass overrides `perform_now` directly (rare, but possible) and keeps the `Current.set` block syntactically obvious.
+- **A concern, not a `before_action do` block in `ApplicationController`.** `ApplicationController` is a file you edit constantly. Anything injected there has to be recognised again on the next run by matching a string inside it — which stops working the moment someone reformats the block, and then a re-run happily injects a second copy. Putting the setter in `app/controllers/concerns/set_current_request_id.rb` reduces our footprint in your controller to one `include` line, makes the idempotency guard a file-existence check instead of a substring match, and makes removing it obvious.
 - **Default-deny regex in `filter_parameters`.** A new gem or integration that adds a `stripe_secret_key` field gets filtered automatically, without anyone updating the list. Belt-and-braces alongside the explicit names.
 
 ## Idempotency
@@ -26,7 +28,8 @@ The template is safe to re-run. Each file edit uses a distinctive content marker
 
 - `Current` — skips if `attribute :request_id` is already present
 - `ApplicationJob` — skips if `attr_accessor :request_id` is already present
-- `ApplicationController` — skips if `Current.request_id = request.request_id` is already present
+- `SetCurrentRequestId` — created with `skip: true`, so your edits survive
+- `ApplicationController` — skips if `include SetCurrentRequestId` is already present
 - `filter_parameter_logging.rb` — skips if `:webhook_secret` is already present (our marker), preserving any hand-edits you made after running the template once
 
 ## Re-running Safely

--- a/_templates/request-id-context/template.rb
+++ b/_templates/request-id-context/template.rb
@@ -76,29 +76,50 @@ end
 # --- 3. app/controllers/application_controller.rb -----------------------------
 
 application_controller_path = "app/controllers/application_controller.rb"
+concern_path = "app/controllers/concerns/set_current_request_id.rb"
 
-controller_block = <<~'RUBY'
-  before_action do
-    Current.request_id = request.request_id
-    # Make request_id flow into Rails.event lines emitted from controllers.
-    # The same setter runs inside ApplicationJob#perform_now for jobs.
-    Rails.event.set_context(request_id: request.request_id) if Rails.respond_to?(:event)
+# The setter lives in a concern rather than as an anonymous `before_action do`
+# block injected into ApplicationController. ApplicationController is a file
+# users edit constantly, so anything we inject there has to be recognised again
+# on the next run by matching a string inside it — fragile, and it silently
+# stops working the moment someone reformats the block. A concern reduces our
+# footprint in that file to a single `include` line, and makes both the
+# idempotency check and the undo obvious.
+create_file concern_path, <<~'RUBY', skip: true
+  module SetCurrentRequestId
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :set_current_request_id
+    end
+
+    private
+
+    # `Rails.event.set_context` makes request_id flow into Rails.event lines
+    # emitted from controllers. The same setter runs inside
+    # ApplicationJob#perform_now for jobs. Guarded so pre-8.1 apps skip it.
+    def set_current_request_id
+      Current.request_id = request.request_id
+      Rails.event.set_context(request_id: request.request_id) if Rails.respond_to?(:event)
+    end
   end
 RUBY
 
-# inject_into_class does not auto-indent; pre-indent the block by two spaces.
-controller_block_indented = controller_block.lines.map { |l| l.strip.empty? ? "\n" : "  #{l}" }.join + "\n"
-
 if File.exist?(application_controller_path)
-  if File.read(application_controller_path).include?("Current.request_id = request.request_id")
-    say "✓ ApplicationController already sets Current.request_id, skipping.", :yellow
+  if File.read(application_controller_path).include?("include SetCurrentRequestId")
+    say "✓ ApplicationController already includes SetCurrentRequestId, skipping.", :yellow
   else
-    inject_into_class application_controller_path, "ApplicationController", controller_block_indented
-    say "✓ Added before_action setting Current.request_id to ApplicationController.", :green
+    inject_into_class application_controller_path, "ApplicationController",
+      "  include SetCurrentRequestId\n"
+    say "✓ Included SetCurrentRequestId in ApplicationController.", :green
   end
 else
-  create_file application_controller_path, "class ApplicationController < ActionController::Base\n#{controller_block_indented}end\n"
-  say "✓ Created ApplicationController with request_id before_action.", :green
+  create_file application_controller_path, <<~'RUBY'
+    class ApplicationController < ActionController::Base
+      include SetCurrentRequestId
+    end
+  RUBY
+  say "✓ Created ApplicationController including SetCurrentRequestId.", :green
 end
 
 # --- 4. config/initializers/filter_parameter_logging.rb -----------------------

--- a/test/templates/request_id_context_test.rb
+++ b/test/templates/request_id_context_test.rb
@@ -25,12 +25,20 @@ class RequestIdContextTest < TemplateTestCase
     assert_match(/def perform_now/, application_job)
     assert_match(/Current\.set\(request_id: request_id\)/, application_job)
 
-    # 3. ApplicationController sets Current.request_id in a before_action
+    # 3. A SetCurrentRequestId concern holds the setter; ApplicationController
+    #    only gains an include line.
+    concern_path = "#{@app_dir}/app/controllers/concerns/set_current_request_id.rb"
+    assert File.exist?(concern_path), "SetCurrentRequestId concern should be created"
+    concern = File.read(concern_path)
+    assert_match(/module SetCurrentRequestId/, concern)
+    assert_match(/extend ActiveSupport::Concern/, concern)
+    assert_match(/before_action :set_current_request_id/, concern)
+    assert_match(/Current\.request_id = request\.request_id/, concern)
+    assert_match(/Rails\.event\.set_context\(request_id: request\.request_id\) if Rails\.respond_to\?\(:event\)/, concern)
+
     application_controller_path = "#{@app_dir}/app/controllers/application_controller.rb"
     application_controller = File.read(application_controller_path)
-    assert_match(/before_action do/, application_controller)
-    assert_match(/Current\.request_id = request\.request_id/, application_controller)
-    assert_match(/Rails\.event\.set_context\(request_id: request\.request_id\) if Rails\.respond_to\?\(:event\)/, application_controller)
+    assert_match(/^  include SetCurrentRequestId$/, application_controller)
 
     # 4. filter_parameter_logging.rb includes the baseline and default-deny regex
     filter_path = "#{@app_dir}/config/initializers/filter_parameter_logging.rb"
@@ -43,6 +51,7 @@ class RequestIdContextTest < TemplateTestCase
     current_before = File.read(current_path)
     application_job_before = File.read(application_job_path)
     application_controller_before = File.read(application_controller_path)
+    concern_before = File.read(concern_path)
     filter_before = File.read(filter_path)
 
     apply_template("request-id-context")
@@ -53,13 +62,16 @@ class RequestIdContextTest < TemplateTestCase
       "Re-running the template must not modify app/jobs/application_job.rb"
     assert_equal application_controller_before, File.read(application_controller_path),
       "Re-running the template must not modify app/controllers/application_controller.rb"
+    assert_equal concern_before, File.read(concern_path),
+      "Re-running the template must not modify the SetCurrentRequestId concern"
     assert_equal filter_before, File.read(filter_path),
       "Re-running the template must not modify config/initializers/filter_parameter_logging.rb"
 
     # Single occurrence of each marker, no duplication
     assert_equal 1, File.read(current_path).scan(/attribute :request_id/).count
     assert_equal 1, File.read(application_job_path).scan(/attr_accessor :request_id/).count
-    assert_equal 1, File.read(application_controller_path).scan(/Current\.request_id = request\.request_id/).count
+    assert_equal 1, File.read(application_controller_path).scan(/include SetCurrentRequestId/).count
+    assert_equal 1, File.read(concern_path).scan(/Current\.request_id = request\.request_id/).count
     assert_equal 1, File.read(filter_path).scan(/:webhook_secret/).count
 
     assert_rails_boots


### PR DESCRIPTION
## What changes

Replaces the anonymous `before_action do ... end` block that #46 injected into `ApplicationController` with a concern at `app/controllers/concerns/set_current_request_id.rb`, matching how usingrails does it.

`ApplicationController` gains exactly one line:

```ruby
class ApplicationController < ActionController::Base
  include SetCurrentRequestId
end
```

## Why

`ApplicationController` is a file users edit constantly. Anything we inject into it has to be recognised again on the next run by matching a string *inside* it — here, `Current.request_id = request.request_id`. That guard has two failure modes:

- Someone reformats or rewraps the block → the substring no longer matches → a re-run injects a **second copy** of the whole `before_action`.
- Someone deliberately deletes the block → we can't tell that from "never installed", so there's no way to opt out short of leaving a comment behind.

A concern moves the code into a file we own outright. The idempotency guard becomes `create_file ..., skip: true` (file existence) for the concern plus a one-line `include SetCurrentRequestId` check for the controller — both stable under reformatting. Removing the feature becomes "delete one line and one file" instead of "find the block we injected".

## Behaviour

Unchanged. Same `before_action`, same two assignments, still guarded with `Rails.respond_to?(:event)` so pre-8.1 apps skip the `Rails.event.set_context` call.

```ruby
module SetCurrentRequestId
  extend ActiveSupport::Concern

  included do
    before_action :set_current_request_id
  end

  private

  def set_current_request_id
    Current.request_id = request.request_id
    Rails.event.set_context(request_id: request.request_id) if Rails.respond_to?(:event)
  end
end
```

## Tests

`test/templates/request_id_context_test.rb` now asserts the concern's contents and that `ApplicationController` carries exactly one `include SetCurrentRequestId`, alongside the existing idempotency re-apply and `assert_rails_boots`. 1 run, 53 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)