### PR TITLE
fix(active-job-json-logs): stop leaking record attributes from nested job arguments

### DIFF
--- a/_templates/active-job-json-logs/active-job-json-logs.md
+++ b/_templates/active-job-json-logs/active-job-json-logs.md
@@ -11,7 +11,7 @@ No gem is added — this uses stdlib `ActiveSupport::Notifications`.
 ## What It Does
 
 - Subscribes to `perform.active_job` and emits a single JSON line per job execution
-- Filters job arguments through `Rails.application.config.filter_parameters` (records become GlobalIDs)
+- Reduces every Active Record argument to a GlobalID — at any nesting depth — then filters what's left through `Rails.application.config.filter_parameters`
 - Prepends `ActiveJob::Base#tag_logger` with a no-op so the `[ActiveJob] [JobClass] [job_id]` TaggedLogging prefix is gone from every line the job emits
 - Detaches the default `ActiveJob::LogSubscriber` in production/staging so the classic `Performing… / Performed…` lines don't double up
 - Wraps the detach/prepend in a `Rails.env.production? || Rails.env.staging?` guard so dev/test boot cleanly and you can still read the default logs when debugging locally
@@ -49,7 +49,28 @@ Fields that aren't applicable get dropped via `.compact`:
 - **Production/staging only.** The detach + prepend run inside a `Rails.env.production? || Rails.env.staging?` guard so dev/test see the familiar default logs when you're debugging a job locally. The subscriber itself is registered in all environments — it's a no-op when no jobs fire.
 - **`after_initialize` for the detach.** `ActiveJob::LogSubscriber` is loaded lazily; detaching it at boot before it's attached is a no-op. `after_initialize` makes the detach reliable.
 - **Filtered args.** Hash arguments go through `ActiveSupport::ParameterFilter` so secrets in job payloads (`password`, `token`, `api_key`) are scrubbed using your existing `filter_parameters` config.
-- **GlobalID for records.** ActiveRecord arguments serialize as `gid://app/Model/id` rather than dumping the whole object, keeping the line small and stable.
+- **GlobalID for records, at every depth.** `perform.active_job` fires *after* deserialization, so arguments arrive as live objects. An Active Record instance handed to `to_json` renders its whole attribute set — every column, `email` and `password_digest` included. `JobArgumentLogging#globalize` walks hashes and arrays recursively so no record survives to serialization; each becomes `gid://app/Model/id`.
+
+## The Nesting Hazard
+
+A top-level-only conversion looks correct and passes the obvious test:
+
+```ruby
+# Broken — only checks the outermost args
+Array(job.arguments).map do |arg|
+  arg.respond_to?(:to_global_id) ? arg.to_global_id.to_s : arg
+end
+```
+
+`ActionMailer::MailDeliveryJob` nests its record argument inside a hash, so this leaks the entire user row on every single `deliver_later`:
+
+```json
+"args": ["UserMailer", "confirmation", "deliver_now",
+  {"args": [{"id": 1, "email": "sarah@example.com",
+             "password_digest": "$2a$12$Z3hw…"}]}]
+```
+
+`filter_parameters` does not save you here — the record is not a hash, so there are no keys to match on. Only the recursive pass fixes it. Same hole applies to any job whose arguments are a hash or array of records.
 
 ## Composition
 

--- a/_templates/active-job-json-logs/template.rb
+++ b/_templates/active-job-json-logs/template.rb
@@ -14,24 +14,50 @@ end
 
 initializer_body = <<~'RUBY'
   # One JSON line per Active Job execution, replacing Rails' default
-  # `Performing…` / `Performed…` output entirely. Argument records are
-  # emitted as GlobalIDs; hash args funnel through filter_parameters.
+  # `Performing…` / `Performed…` output entirely. Arguments are rendered by
+  # `JobArgumentLogging` so records become GlobalIDs and sensitive hash keys
+  # become `[FILTERED]` before they reach the line.
+
+  # Renders an Active Job argument list for the log line.
+  #
+  # `perform.active_job` fires after deserialization, so arguments arrive as
+  # live objects — an Active Record instance handed straight to `to_json`
+  # renders its whole attribute set (`email`, `password_digest`, …). Records
+  # therefore have to be reduced to GlobalIDs at *every* depth, not just at
+  # the top level: `ActionMailer::MailDeliveryJob` nests its record argument
+  # inside a Hash (`{args: [user], params: nil}`), so a top-level-only pass
+  # leaks the whole user row on every `deliver_later`. Any job taking a hash
+  # or array of records has the same hole.
+  #
+  # `globalize` walks the structure first so no record survives to the
+  # `filter` pass, then `filter` applies `config.filter_parameters` to what
+  # remains — the same redaction controllers get on their params.
+  module JobArgumentLogging
+    module_function
+
+    def render(arguments)
+      filter.filter(args: globalize(Array(arguments)))[:args]
+    end
+
+    def globalize(value)
+      case value
+      when Hash then value.transform_values { globalize(_1) }
+      when Array then value.map { globalize(_1) }
+      else value.respond_to?(:to_global_id) ? value.to_global_id.to_s : value
+      end
+    end
+
+    # Built once: `config.filter_parameters` compiles every configured
+    # pattern, and this runs on every job execution.
+    def filter
+      @filter ||= ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    end
+  end
 
   ActiveSupport::Notifications.subscribe("perform.active_job") do |*args|
     event = ActiveSupport::Notifications::Event.new(*args)
     job = event.payload[:job]
     err = event.payload[:exception_object]
-
-    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
-    serialized_args = Array(job.arguments).map do |arg|
-      if arg.respond_to?(:to_global_id)
-        arg.to_global_id.to_s
-      elsif arg.is_a?(Hash)
-        filter.filter(arg)
-      else
-        arg
-      end
-    end
 
     fields = {
       event:         "job.perform",
@@ -40,7 +66,7 @@ initializer_body = <<~'RUBY'
       attempt:       job.executions,
       job_id:        job.job_id,
       request_id:    (Current.request_id if defined?(Current) && Current.respond_to?(:request_id)),
-      args:          serialized_args.presence,
+      args:          JobArgumentLogging.render(job.arguments).presence,
       duration_ms:   event.duration.to_i,
       status:        err ? "error" : "ok",
       error_class:   err&.class&.name,

--- a/test/templates/active_job_json_logs_test.rb
+++ b/test/templates/active_job_json_logs_test.rb
@@ -17,6 +17,8 @@ class ActiveJobJsonLogsTest < TemplateTestCase
     assert_match(/ActiveJob::Base\.prepend\(ActiveJobNoTagging\)/, initializer)
     assert_match(/ActiveSupport::ParameterFilter/, initializer)
     assert_match(/to_global_id/, initializer)
+    assert_match(/module JobArgumentLogging/, initializer)
+    assert_match(/JobArgumentLogging\.render\(job\.arguments\)/, initializer)
     assert_match(/SolidQueue::ReadyExecution\.count rescue nil/, initializer)
     assert_match(/defined\?\(Current\)/, initializer)
 
@@ -38,5 +40,29 @@ class ActiveJobJsonLogsTest < TemplateTestCase
       "Re-running the template must not modify the initializer"
 
     assert_rails_boots
+    assert_records_globalize_at_every_depth
+  end
+
+  private
+
+  # Records nested inside a hash or array argument must reduce to GlobalIDs
+  # too. A top-level-only conversion leaves them to `to_json`, which renders
+  # the whole attribute set — `ActionMailer::MailDeliveryJob` hits this on
+  # every `deliver_later` because it nests its record inside a hash.
+  def assert_records_globalize_at_every_depth
+    probe = File.join(@app_dir, "tmp/job_argument_logging_probe.rb")
+    File.write(probe, <<~RUBY)
+      record = Class.new { def to_global_id = "gid://app/User/1" }.new
+      puts JobArgumentLogging.render([ record, { args: [ record ] }, [ record ] ]).to_json
+    RUBY
+
+    Bundler.with_unbundled_env do
+      Dir.chdir(@app_dir) do
+        output = `bundle exec rails runner tmp/job_argument_logging_probe.rb 2>&1`
+        assert_includes output,
+          '["gid://app/User/1",{"args":["gid://app/User/1"]},["gid://app/User/1"]]',
+          "records must reduce to GlobalIDs at every depth, not just the top level: #{output}"
+      end
+    end
   end
 end


### PR DESCRIPTION
The `active-job-json-logs` initializer only converted **top-level** Active Record
arguments to GlobalIDs. `perform.active_job` fires *after* deserialization, so a
record nested inside a hash or array reached `to_json` as a live object — which
renders its whole attribute set.

`ActionMailer::MailDeliveryJob` nests its record argument inside a hash, so every
`deliver_later` logged the entire user row:

```json
"args": ["UserMailer", "confirmation", "deliver_now",
  {"args": [{"id": 1, "email": "sarah@example.com",
             "password_digest": "$2a$12$Z3hw…"}]}]
```

`filter_parameters` can't catch this: the record isn't a hash, so there are no
keys to match on.

## The fix

A `JobArgumentLogging` module in the generated initializer:

- `globalize` walks hashes and arrays recursively, so no record survives to
  serialization — each becomes `gid://app/Model/id`.
- `filter` then applies `config.filter_parameters` to what remains.
- The `ActiveSupport::ParameterFilter` is memoized instead of rebuilt on every
  job execution (it compiles every configured pattern).

## Verification

The test boots the generated app and runs a probe through `rails runner`,
asserting records reduce to GlobalIDs at top level, inside a hash, and inside an
array. `bundle exec jekyll build` is clean.
